### PR TITLE
Morph an intermediate message catch event into a timer event

### DIFF
--- a/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
+++ b/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
@@ -38,11 +38,13 @@ describe('customs - replaceMenu', function() {
     openPopup(startEvent);
 
     const endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
-          messageStartEntry = queryEntry(popupMenu, 'replace-with-message-start');
+          messageStartEntry = queryEntry(popupMenu, 'replace-with-message-start'),
+          timerStartEntry = queryEntry(popupMenu, 'replace-with-timer-start');
 
     // then
     expect(endEventEntry).to.exist;
     expect(messageStartEntry).to.exist;
+    expect(timerStartEntry).to.exist;
 
   }));
 
@@ -93,11 +95,13 @@ describe('customs - replaceMenu', function() {
     openPopup(timerEvent);
 
     const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
-          endEventEntry = queryEntry(popupMenu, 'replace-with-none-end');
+          endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
+          timerEventEntry = queryEntry(popupMenu, 'replace-with-timer-intermediate-catch');
 
     // then
     expect(startEventEntry).to.exist;
     expect(endEventEntry).to.exist;
+    expect(timerEventEntry).to.exist;
 
   }));
 

--- a/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
+++ b/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
@@ -1,6 +1,7 @@
 export const AVAILABLE_REPLACE_ELEMENTS = [
   'replace-with-service-task',
   'replace-with-message-intermediate-catch',
+  'replace-with-timer-intermediate-catch',
   'replace-with-none-start',
   'replace-with-none-end',
   'replace-with-conditional-flow',


### PR DESCRIPTION
This pull request fixes the following issue:

* I can morph an intermediate message catch event into a timer event

Closes #70 