### PR TITLE
Multi Instance Support

### DIFF
--- a/client/src/app/tabs/bpmn/custom/CustomReplaceMenuProvider.js
+++ b/client/src/app/tabs/bpmn/custom/CustomReplaceMenuProvider.js
@@ -11,7 +11,16 @@
 import ReplaceMenuProvider from 'bpmn-js/lib/features/popup-menu/ReplaceMenuProvider';
 
 import {
-  AVAILABLE_REPLACE_ELEMENTS as availableElements
+  isEventSubProcess
+} from 'bpmn-js/lib/util/DiUtil';
+
+import {
+  isAny
+} from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
+
+import {
+  AVAILABLE_REPLACE_ELEMENTS as availableElements,
+  AVAILABLE_LOOP_ENTRIES as availableLoopEntries
 } from './modeler-options/Options';
 
 export default class CustomReplaceMenuProvider extends ReplaceMenuProvider {
@@ -26,12 +35,23 @@ export default class CustomReplaceMenuProvider extends ReplaceMenuProvider {
     return options.filter(option => availableElements.indexOf(option.id) != -1);
   }
 
-  _getLoopEntries(element) {
-    return [];
-  }
-
   getHeaderEntries(element) {
-    return [];
+
+    let headerEntries = [];
+
+    if (
+      isAny(element, [ 'bpmn:ReceiveTask', 'bpmn:ServiceTask', 'bpmn:SubProcess' ]) &&
+      !isEventSubProcess(element)
+    ) {
+
+      const loopEntries = this._getLoopEntries(element);
+
+      headerEntries = loopEntries.filter(
+        entry => availableLoopEntries.indexOf(entry.id) != -1
+      );
+    }
+
+    return headerEntries;
   }
 }
 

--- a/client/src/app/tabs/bpmn/custom/CustomRules.js
+++ b/client/src/app/tabs/bpmn/custom/CustomRules.js
@@ -16,12 +16,12 @@ import {
 
 import {
   isLabel
-} from 'bpmn-js/lib//util/LabelUtil';
+} from 'bpmn-js/lib/util/LabelUtil';
 
 import {
   is,
   getBusinessObject
-} from 'bpmn-js/lib//util/ModelUtil';
+} from 'bpmn-js/lib/util/ModelUtil';
 
 
 import {
@@ -69,8 +69,12 @@ export default class CustomRules extends BpmnRules {
    * this must be reflected in the rules.
    */
     function isBoundaryCandidate(element) {
-      return isBoundaryEvent(element) ||
-          ((is(element, 'bpmn:IntermediateCatchEvent') ||is(element, 'bpmn:IntermediateThrowEvent')) && !element.parent);
+      return isBoundaryEvent(element) || (
+        (
+          is(element, 'bpmn:IntermediateCatchEvent') ||
+          is(element, 'bpmn:IntermediateThrowEvent')
+        ) && !element.parent
+      );
     }
 
     function isForCompensation(e) {
@@ -80,9 +84,9 @@ export default class CustomRules extends BpmnRules {
     function isReceiveTaskAfterEventBasedGateway(element) {
       return (
         is(element, 'bpmn:ReceiveTask') &&
-      find(element.incoming, function(incoming) {
-        return is(incoming.source, 'bpmn:EventBasedGateway');
-      })
+        find(element.incoming, function(incoming) {
+          return is(incoming.source, 'bpmn:EventBasedGateway');
+        })
       );
     }
 

--- a/client/src/app/tabs/bpmn/custom/__tests__/CustomContextPadProviderSpec.js
+++ b/client/src/app/tabs/bpmn/custom/__tests__/CustomContextPadProviderSpec.js
@@ -46,11 +46,11 @@ describe('customs - context-pad', function() {
 
       getBpmnJS().invoke(function(elementRegistry, contextPad) {
 
-        var element = typeof elementOrId === 'string' ? elementRegistry.get(elementOrId) : elementOrId;
+        const element = typeof elementOrId === 'string' ? elementRegistry.get(elementOrId) : elementOrId;
 
         contextPad.open(element, true);
 
-        var entries = contextPad._current.entries;
+        const entries = contextPad._current.entries;
 
         expectedEntries.forEach(function(name) {
 

--- a/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
+++ b/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
@@ -126,12 +126,16 @@ describe('customs - replaceMenu', function() {
 
     const serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
           collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
-          expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess');
+          expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
+          sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
+          parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
     // then
     expect(serviceTaskEntry).to.exist;
     expect(collapsedSubProcessEntry).to.exist;
     expect(expandedSubProcessEntry).to.exist;
+    expect(sequentialMultiInstanceEntry).to.exist;
+    expect(parallelMultiInstanceEntry).to.exist;
 
   }));
 
@@ -146,12 +150,16 @@ describe('customs - replaceMenu', function() {
 
     const receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
           collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
-          expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess');
+          expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
+          sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
+          parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
     // then
     expect(collapsedSubProcessEntry).to.exist;
     expect(expandedSubProcessEntry).to.exist;
     expect(receiveTaskEntry).to.exist;
+    expect(sequentialMultiInstanceEntry).to.exist;
+    expect(parallelMultiInstanceEntry).to.exist;
 
   }));
 
@@ -220,12 +228,16 @@ describe('customs - replaceMenu', function() {
 
     const receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
           serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
-          expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess');
+          expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
+          sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
+          parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
     // then
     expect(serviceTaskEntry).to.exist;
     expect(expandedSubProcessEntry).to.exist;
     expect(receiveTaskEntry).to.exist;
+    expect(sequentialMultiInstanceEntry).to.exist;
+    expect(parallelMultiInstanceEntry).to.exist;
 
   }));
 
@@ -238,10 +250,14 @@ describe('customs - replaceMenu', function() {
 
     openPopup(subProcess);
 
-    const collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess');
+    const collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
+          sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
+          parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
     // then
     expect(collapsedSubProcessEntry).to.exist;
+    expect(sequentialMultiInstanceEntry).to.exist;
+    expect(parallelMultiInstanceEntry).to.exist;
 
   }));
 

--- a/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
+++ b/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
@@ -38,3 +38,8 @@ export const AVAILABLE_CONTEXTPAD_ENTRIES = [
   'connect',
   'replace'
 ];
+
+export const AVAILABLE_LOOP_ENTRIES = [
+  'toggle-parallel-mi',
+  'toggle-sequential-mi'
+];

--- a/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
@@ -77,7 +77,7 @@ function createGeneralTabGroups(element, bpmnFactory, canvas, translate) {
   messageProps(generalGroup, element, bpmnFactory, translate);
   timerProps(generalGroup, element, bpmnFactory, translate);
 
-  var multiInstanceGroup = {
+  const multiInstanceGroup = {
     id: 'multiInstance',
     label: translate('Multi Instance'),
     entries: []

--- a/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
@@ -38,6 +38,8 @@ import timerProps from './parts/TimerEventProps';
 
 import payloadMappingsProps from './parts/PayloadMappingsProps';
 
+import multiInstanceProps from './parts/MultiInstanceProps';
+
 const getInputOutputParameterLabel = param => {
 
   if (is(param, 'zeebe:InputParameter')) {
@@ -75,8 +77,16 @@ function createGeneralTabGroups(element, bpmnFactory, canvas, translate) {
   messageProps(generalGroup, element, bpmnFactory, translate);
   timerProps(generalGroup, element, bpmnFactory, translate);
 
+  var multiInstanceGroup = {
+    id: 'multiInstance',
+    label: translate('Multi Instance'),
+    entries: []
+  };
+  multiInstanceProps(multiInstanceGroup, element, bpmnFactory, translate);
+
   return [
-    generalGroup
+    generalGroup,
+    multiInstanceGroup
   ];
 }
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/BoundaryEventTimerEventDefinitionSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/BoundaryEventTimerEventDefinitionSpec.js
@@ -47,7 +47,7 @@ function getGeneralTab(container) {
 }
 
 function getDetailsGroup(container) {
-  var tab = getGeneralTab(container);
+  const tab = getGeneralTab(container);
   return domQuery('div[data-group="details"]', tab);
 }
 
@@ -56,12 +56,12 @@ function getEntry(container, entryId) {
 }
 
 function getInputField(container, entryId, inputName) {
-  var selector = 'input' + (inputName ? '[name="' + inputName + '"]' : '');
+  const selector = 'input' + (inputName ? '[name="' + inputName + '"]' : '');
   return domQuery(selector, getEntry(container, entryId));
 }
 
 function getSelectField(container, entryId, selectName) {
-  var selector = 'select' + (selectName ? '[name="' + selectName + '"]' : '');
+  const selector = 'select' + (selectName ? '[name="' + selectName + '"]' : '');
   return domQuery(selector, getEntry(container, entryId));
 }
 
@@ -70,8 +70,8 @@ function getTimerDefinitionTypeField(container) {
 }
 
 function selectTimerDefinitionType(type, container) {
-  var selectBox = getTimerDefinitionTypeField(container);
-  var option = find(selectBox.options, function(o) {
+  const selectBox = getTimerDefinitionTypeField(container);
+  let option = find(selectBox.options, function(o) {
     return o.value === type;
   });
   option.selected = 'selected';
@@ -96,15 +96,15 @@ function isInputHidden(node) {
 
 describe('boundary-event-timer-event-properties', function() {
 
-  var diagramXML = require('./BoundaryEventTimerEventDefinition.bpmn');
+  const diagramXML = require('./BoundaryEventTimerEventDefinition.bpmn');
 
-  var testModules = [
+  const testModules = [
     coreModule, selectionModule, modelingModule,
     propertiesPanelModule,
     propertiesProviderModule
   ];
 
-  var container;
+  let container;
 
   beforeEach(function() {
     container = TestContainer.get(this);
@@ -117,7 +117,7 @@ describe('boundary-event-timer-event-properties', function() {
 
   beforeEach(inject(function(commandStack, propertiesPanel) {
 
-    var undoButton = document.createElement('button');
+    let undoButton = document.createElement('button');
     undoButton.textContent = 'UNDO';
 
     undoButton.addEventListener('click', function() {
@@ -132,7 +132,7 @@ describe('boundary-event-timer-event-properties', function() {
 
   describe('property controls', function() {
 
-    var container;
+    let container;
 
     beforeEach(inject(function(propertiesPanel) {
       container = propertiesPanel._container;
@@ -142,7 +142,7 @@ describe('boundary-event-timer-event-properties', function() {
     it('should fetch no timer definition type', inject(function(elementRegistry, selection) {
 
       // given
-      var shape = elementRegistry.get('WITHOUT_TYPE');
+      const shape = elementRegistry.get('WITHOUT_TYPE');
 
       // when
       selection.select(shape);
@@ -156,7 +156,7 @@ describe('boundary-event-timer-event-properties', function() {
     it('should fetch timeDuration as timer definition type', inject(function(elementRegistry, selection) {
 
       // given
-      var shape = elementRegistry.get('TIME_DURATION');
+      const shape = elementRegistry.get('TIME_DURATION');
 
       // when
       selection.select(shape);
@@ -170,7 +170,7 @@ describe('boundary-event-timer-event-properties', function() {
     it('should fetch timeCycle as timer definition type', inject(function(elementRegistry, selection) {
 
       // given
-      var shape = elementRegistry.get('TIME_CYCLE');
+      const shape = elementRegistry.get('TIME_CYCLE');
 
       // when
       selection.select(shape);
@@ -185,7 +185,7 @@ describe('boundary-event-timer-event-properties', function() {
 
   describe('change timer definition type', function() {
 
-    var container;
+    let container;
 
     beforeEach(inject(function(propertiesPanel) {
       container = propertiesPanel._container;
@@ -193,15 +193,15 @@ describe('boundary-event-timer-event-properties', function() {
 
     describe('from undefined', function() {
 
-      var timerDefinition;
+      let timerDefinition;
 
       beforeEach(inject(function(elementRegistry, selection) {
 
         // when
-        var shape = elementRegistry.get('WITHOUT_TYPE');
+        const shape = elementRegistry.get('WITHOUT_TYPE');
         selection.select(shape);
 
-        var bo = getBusinessObject(shape);
+        const bo = getBusinessObject(shape);
         timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
       }));
 
@@ -359,15 +359,15 @@ describe('boundary-event-timer-event-properties', function() {
 
     describe('from timeCycle', function() {
 
-      var timerDefinition;
+      let timerDefinition;
 
       beforeEach(inject(function(elementRegistry, selection) {
 
         // when
-        var shape = elementRegistry.get('TIME_CYCLE');
+        const shape = elementRegistry.get('TIME_CYCLE');
         selection.select(shape);
 
-        var bo = getBusinessObject(shape);
+        const bo = getBusinessObject(shape);
         timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
       }));
 
@@ -534,15 +534,15 @@ describe('boundary-event-timer-event-properties', function() {
 
     describe('from timeDuration', function() {
 
-      var timerDefinition;
+      let timerDefinition;
 
       beforeEach(inject(function(elementRegistry, selection) {
 
         // when
-        var shape = elementRegistry.get('TIME_DURATION');
+        const shape = elementRegistry.get('TIME_DURATION');
         selection.select(shape);
 
-        var bo = getBusinessObject(shape);
+        const bo = getBusinessObject(shape);
         timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
       }));
 
@@ -710,7 +710,7 @@ describe('boundary-event-timer-event-properties', function() {
 
   describe('change timer definition', function() {
 
-    var container;
+    let container;
 
     beforeEach(inject(function(propertiesPanel) {
       container = propertiesPanel._container;
@@ -718,16 +718,16 @@ describe('boundary-event-timer-event-properties', function() {
 
     describe('of time duration', function() {
 
-      var input, timeDuration;
+      let input, timeDuration;
 
       beforeEach(inject(function(elementRegistry, selection) {
 
         // given
-        var shape = elementRegistry.get('TIME_DURATION');
+        const shape = elementRegistry.get('TIME_DURATION');
         selection.select(shape);
 
-        var bo = getBusinessObject(shape);
-        var timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
+        const bo = getBusinessObject(shape);
+        const timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
         timeDuration = timerDefinition.timeDuration;
 
         input = getTimerDefinitionField(container);
@@ -803,16 +803,16 @@ describe('boundary-event-timer-event-properties', function() {
 
     describe('of time cycle', function() {
 
-      var input, timeCycle;
+      let input, timeCycle;
 
       beforeEach(inject(function(elementRegistry, selection) {
 
         // given
-        var shape = elementRegistry.get('TIME_CYCLE');
+        const shape = elementRegistry.get('TIME_CYCLE');
         selection.select(shape);
 
-        var bo = getBusinessObject(shape);
-        var timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
+        const bo = getBusinessObject(shape);
+        const timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
         timeCycle = timerDefinition.timeCycle;
 
         input = getTimerDefinitionField(container);
@@ -892,11 +892,11 @@ describe('boundary-event-timer-event-properties', function() {
     it('should set timer event definition field as invalid', inject(function(propertiesPanel, elementRegistry, selection) {
 
       // given
-      var shape = elementRegistry.get('TIME_CYCLE');
+      const shape = elementRegistry.get('TIME_CYCLE');
       selection.select(shape);
 
-      var container = propertiesPanel._container;
-      var input = getTimerDefinitionField(container);
+      const container = propertiesPanel._container;
+      const input = getTimerDefinitionField(container);
 
       // when
       triggerValue(input, '', 'change');

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/MultiInstanceLoop.bpmn
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/MultiInstanceLoop.bpmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0l1dxrj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.7.0-dev">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1">
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="inputCollection" inputElement="inputElement" outputCollection="outputCollection" outputElement="outputElement" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_empty">
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true" />
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="180" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_empty_di" bpmnElement="ServiceTask_empty">
+        <dc:Bounds x="330" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/MultiInstanceLoopSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/MultiInstanceLoopSpec.js
@@ -1,0 +1,752 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  bootstrapModeler,
+  inject
+} from 'bpmn-js/test/helper';
+
+import {
+  triggerValue
+} from './helper';
+
+import TestContainer from 'mocha-test-container-support';
+
+import propertiesPanelModule from 'bpmn-js-properties-panel';
+
+import {
+  classes as domClasses,
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+
+import coreModule from 'bpmn-js/lib/core';
+import selectionModule from 'diagram-js/lib/features/selection';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import propertiesProviderModule from '../';
+import zeebeModdleExtensions from '../../zeebe-bpmn-moddle/zeebe';
+
+describe('customs - multi instance loop', function() {
+
+  const diagramXML = require('./MultiInstanceLoop.bpmn');
+
+  const testModules = [
+    coreModule, selectionModule, modelingModule,
+    propertiesPanelModule,
+    propertiesProviderModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+
+  beforeEach(inject(function(commandStack, propertiesPanel) {
+
+    const undoButton = document.createElement('button');
+    undoButton.textContent = 'UNDO';
+
+    undoButton.addEventListener('click', () => {
+      commandStack.undo();
+    });
+
+    container.appendChild(undoButton);
+
+    propertiesPanel.attachTo(container);
+  }));
+
+  describe('of inputCollection', function() {
+
+    let bo;
+
+    describe('create', function() {
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_empty');
+        selection.select(shape);
+
+        bo = getBusinessObject(shape);
+
+        // assume
+        expect(getZeebeLoopCharacteristics(bo)).to.be.undefined;
+
+        const input = getInputField(
+          container,
+          'camunda-multiInstance-inputCollection',
+          'inputCollection'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      it('should execute', function() {
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.exist;
+        expect(loopCharacteristics.inputCollection).to.equal('foo');
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.be.undefined;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.exist;
+        expect(loopCharacteristics.inputCollection).to.equal('foo');
+      }));
+
+    });
+
+
+    describe('update', function() {
+
+      let input, loopCharacteristics;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_1');
+        selection.select(shape);
+
+        const bo = getBusinessObject(shape);
+
+        loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        input = getInputField(
+          container,
+          'camunda-multiInstance-inputCollection',
+          'inputCollection'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      it('should set input collection field as invalid', function() {
+
+        // when
+        triggerValue(input, '', 'change');
+
+        // then
+        expect(isInputInvalid(input)).to.be.true;
+      });
+
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          // then
+          expect(input.value).to.equal('foo');
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(input.value).to.equal('inputCollection');
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(input.value).to.equal('foo');
+        }));
+
+
+        describe('on the business object', function() {
+
+          it('should execute', function() {
+
+            // then
+            expect(loopCharacteristics.inputCollection).to.equal('foo');
+          });
+
+
+          it('should undo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+
+            // then
+            expect(loopCharacteristics.inputCollection).to.equal('inputCollection');
+          }));
+
+
+          it('should redo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+            commandStack.redo();
+
+            // then
+            expect(loopCharacteristics.inputCollection).to.equal('foo');
+          }));
+
+        });
+
+      });
+
+    });
+
+  });
+
+
+  describe('of inputElement', function() {
+
+    let bo;
+
+    describe('create', function() {
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_empty');
+        selection.select(shape);
+
+        bo = getBusinessObject(shape);
+
+        // assume
+        expect(getZeebeLoopCharacteristics(bo)).to.be.undefined;
+
+        const input = getInputField(
+          container,
+          'camunda-multiInstance-inputElement',
+          'inputElement'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      it('should execute', function() {
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.exist;
+        expect(loopCharacteristics.inputElement).to.equal('foo');
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.be.undefined;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.exist;
+        expect(loopCharacteristics.inputElement).to.equal('foo');
+      }));
+
+    });
+
+
+    describe('update', function() {
+
+      let input, loopCharacteristics;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_1');
+        selection.select(shape);
+
+        const bo = getBusinessObject(shape);
+
+        loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        input = getInputField(
+          container,
+          'camunda-multiInstance-inputElement',
+          'inputElement'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          // then
+          expect(input.value).to.equal('foo');
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(input.value).to.equal('inputElement');
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(input.value).to.equal('foo');
+        }));
+
+
+        describe('on the business object', function() {
+
+          it('should execute', function() {
+
+            // then
+            expect(loopCharacteristics.inputElement).to.equal('foo');
+          });
+
+
+          it('should undo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+
+            // then
+            expect(loopCharacteristics.inputElement).to.equal('inputElement');
+          }));
+
+
+          it('should redo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+            commandStack.redo();
+
+            // then
+            expect(loopCharacteristics.inputElement).to.equal('foo');
+          }));
+
+        });
+
+      });
+
+    });
+
+  });
+
+
+  describe('of outputCollection', function() {
+
+    let bo;
+
+    describe('create', function() {
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_empty');
+        selection.select(shape);
+
+        bo = getBusinessObject(shape);
+
+        // assume
+        expect(getZeebeLoopCharacteristics(bo)).to.be.undefined;
+
+        const input = getInputField(
+          container,
+          'camunda-multiInstance-outputCollection',
+          'outputCollection'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      it('should execute', function() {
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.exist;
+        expect(loopCharacteristics.outputCollection).to.equal('foo');
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.be.undefined;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.exist;
+        expect(loopCharacteristics.outputCollection).to.equal('foo');
+      }));
+
+    });
+
+
+    describe('update', function() {
+
+      let input, loopCharacteristics;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_1');
+        selection.select(shape);
+
+        const bo = getBusinessObject(shape);
+
+        loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        input = getInputField(
+          container,
+          'camunda-multiInstance-outputCollection',
+          'outputCollection'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          // then
+          expect(input.value).to.equal('foo');
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(input.value).to.equal('outputCollection');
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(input.value).to.equal('foo');
+        }));
+
+
+        describe('on the business object', function() {
+
+          it('should execute', function() {
+
+            // then
+            expect(loopCharacteristics.outputCollection).to.equal('foo');
+          });
+
+
+          it('should undo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+
+            // then
+            expect(loopCharacteristics.outputCollection).to.equal('outputCollection');
+          }));
+
+
+          it('should redo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+            commandStack.redo();
+
+            // then
+            expect(loopCharacteristics.outputCollection).to.equal('foo');
+          }));
+
+        });
+
+      });
+
+    });
+
+  });
+
+
+  describe('of outputElement', function() {
+
+    let bo;
+
+    describe('create', function() {
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_empty');
+        selection.select(shape);
+
+        bo = getBusinessObject(shape);
+
+        // assume
+        expect(getZeebeLoopCharacteristics(bo)).to.be.undefined;
+
+        const input = getInputField(
+          container,
+          'camunda-multiInstance-outputElement',
+          'outputElement'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      it('should execute', function() {
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.exist;
+        expect(loopCharacteristics.outputElement).to.equal('foo');
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.be.undefined;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        const loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        expect(loopCharacteristics).to.exist;
+        expect(loopCharacteristics.outputElement).to.equal('foo');
+      }));
+
+    });
+
+
+    describe('update', function() {
+
+      let input, loopCharacteristics;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_1');
+        selection.select(shape);
+
+        const bo = getBusinessObject(shape);
+
+        loopCharacteristics = getZeebeLoopCharacteristics(bo);
+
+        input = getInputField(
+          container,
+          'camunda-multiInstance-outputElement',
+          'outputElement'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          // then
+          expect(input.value).to.equal('foo');
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(input.value).to.equal('outputElement');
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(input.value).to.equal('foo');
+        }));
+
+
+        describe('on the business object', function() {
+
+          it('should execute', function() {
+
+            // then
+            expect(loopCharacteristics.outputElement).to.equal('foo');
+          });
+
+
+          it('should undo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+
+            // then
+            expect(loopCharacteristics.outputElement).to.equal('outputElement');
+          }));
+
+
+          it('should redo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+            commandStack.redo();
+
+            // then
+            expect(loopCharacteristics.outputElement).to.equal('foo');
+          }));
+
+        });
+
+      });
+
+    });
+
+  });
+
+});
+
+
+// helper /////////
+
+const getZeebeLoopCharacteristics = (bo) => {
+
+  const extensions = extensionElementsHelper.getExtensionElements(
+    bo.loopCharacteristics,
+    'zeebe:LoopCharacteristics'
+  );
+  return (extensions || [])[0];
+};
+
+const getGeneralTab = (container) => {
+  return domQuery('div[data-tab="general"]', container);
+};
+
+const getDetailsGroup = (container) => {
+  const tab = getGeneralTab(container);
+  return domQuery('div[data-group="details"]', tab);
+};
+
+const getEntry = (container, entryId) => {
+  return domQuery('div[data-entry="' + entryId + '"]', getDetailsGroup(container));
+};
+
+const getInputField = (container, entryId, inputName) => {
+  const selector = 'input' + (inputName ? '[name="' + inputName + '"]' : '');
+  return domQuery(selector, getEntry(container, entryId));
+};
+
+function isInputInvalid(node) {
+  return domClasses(node).has('invalid');
+}

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/StartEventTimerEventDefinitionSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/StartEventTimerEventDefinitionSpec.js
@@ -47,7 +47,7 @@ function getGeneralTab(container) {
 }
 
 function getDetailsGroup(container) {
-  var tab = getGeneralTab(container);
+  const tab = getGeneralTab(container);
   return domQuery('div[data-group="details"]', tab);
 }
 
@@ -56,12 +56,12 @@ function getEntry(container, entryId) {
 }
 
 function getInputField(container, entryId, inputName) {
-  var selector = 'input' + (inputName ? '[name="' + inputName + '"]' : '');
+  const selector = 'input' + (inputName ? '[name="' + inputName + '"]' : '');
   return domQuery(selector, getEntry(container, entryId));
 }
 
 function getSelectField(container, entryId, selectName) {
-  var selector = 'select' + (selectName ? '[name="' + selectName + '"]' : '');
+  const selector = 'select' + (selectName ? '[name="' + selectName + '"]' : '');
   return domQuery(selector, getEntry(container, entryId));
 }
 
@@ -70,8 +70,8 @@ function getTimerDefinitionTypeField(container) {
 }
 
 function selectTimerDefinitionType(type, container) {
-  var selectBox = getTimerDefinitionTypeField(container);
-  var option = find(selectBox.options, function(o) {
+  const selectBox = getTimerDefinitionTypeField(container);
+  const option = find(selectBox.options, function(o) {
     return o.value === type;
   });
   option.selected = 'selected';
@@ -96,15 +96,15 @@ function isInputHidden(node) {
 
 describe('start-event-timer-event-properties', function() {
 
-  var diagramXML = require('./StartEventTimerEventDefinition.bpmn');
+  const diagramXML = require('./StartEventTimerEventDefinition.bpmn');
 
-  var testModules = [
+  const testModules = [
     coreModule, selectionModule, modelingModule,
     propertiesPanelModule,
     propertiesProviderModule
   ];
 
-  var container;
+  let container;
 
   beforeEach(function() {
     container = TestContainer.get(this);
@@ -117,7 +117,7 @@ describe('start-event-timer-event-properties', function() {
 
   beforeEach(inject(function(commandStack, propertiesPanel) {
 
-    var undoButton = document.createElement('button');
+    const undoButton = document.createElement('button');
     undoButton.textContent = 'UNDO';
 
     undoButton.addEventListener('click', function() {
@@ -132,7 +132,7 @@ describe('start-event-timer-event-properties', function() {
 
   describe('property controls', function() {
 
-    var container;
+    let container;
 
     beforeEach(inject(function(propertiesPanel) {
       container = propertiesPanel._container;
@@ -142,7 +142,7 @@ describe('start-event-timer-event-properties', function() {
     it('should fetch no timer definition type', inject(function(elementRegistry, selection) {
 
       // given
-      var shape = elementRegistry.get('WITHOUT_TYPE');
+      const shape = elementRegistry.get('WITHOUT_TYPE');
 
       // when
       selection.select(shape);
@@ -156,7 +156,7 @@ describe('start-event-timer-event-properties', function() {
     it('should fetch timeDate as timer definition type', inject(function(elementRegistry, selection) {
 
       // given
-      var shape = elementRegistry.get('TIME_DATE');
+      const shape = elementRegistry.get('TIME_DATE');
 
       // when
       selection.select(shape);
@@ -170,7 +170,7 @@ describe('start-event-timer-event-properties', function() {
     it('should fetch timeCycle as timer definition type', inject(function(elementRegistry, selection) {
 
       // given
-      var shape = elementRegistry.get('TIME_CYCLE');
+      const shape = elementRegistry.get('TIME_CYCLE');
 
       // when
       selection.select(shape);
@@ -185,7 +185,7 @@ describe('start-event-timer-event-properties', function() {
 
   describe('change timer definition type', function() {
 
-    var container;
+    let container;
 
     beforeEach(inject(function(propertiesPanel) {
       container = propertiesPanel._container;
@@ -193,15 +193,15 @@ describe('start-event-timer-event-properties', function() {
 
     describe('from undefined', function() {
 
-      var timerDefinition;
+      let timerDefinition;
 
       beforeEach(inject(function(elementRegistry, selection) {
 
         // when
-        var shape = elementRegistry.get('WITHOUT_TYPE');
+        const shape = elementRegistry.get('WITHOUT_TYPE');
         selection.select(shape);
 
-        var bo = getBusinessObject(shape);
+        const bo = getBusinessObject(shape);
         timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
       }));
 
@@ -358,15 +358,15 @@ describe('start-event-timer-event-properties', function() {
 
     describe('from timeDate', function() {
 
-      var timerDefinition;
+      let timerDefinition;
 
       beforeEach(inject(function(elementRegistry, selection) {
 
         // when
-        var shape = elementRegistry.get('TIME_DATE');
+        const shape = elementRegistry.get('TIME_DATE');
         selection.select(shape);
 
-        var bo = getBusinessObject(shape);
+        const bo = getBusinessObject(shape);
         timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
       }));
 
@@ -533,15 +533,15 @@ describe('start-event-timer-event-properties', function() {
 
     describe('from timeCycle', function() {
 
-      var timerDefinition;
+      let timerDefinition;
 
       beforeEach(inject(function(elementRegistry, selection) {
 
         // when
-        var shape = elementRegistry.get('TIME_CYCLE');
+        const shape = elementRegistry.get('TIME_CYCLE');
         selection.select(shape);
 
-        var bo = getBusinessObject(shape);
+        const bo = getBusinessObject(shape);
         timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
       }));
 
@@ -709,7 +709,7 @@ describe('start-event-timer-event-properties', function() {
 
   describe('change timer definition', function() {
 
-    var container;
+    let container;
 
     beforeEach(inject(function(propertiesPanel) {
       container = propertiesPanel._container;
@@ -717,16 +717,16 @@ describe('start-event-timer-event-properties', function() {
 
     describe('of time date', function() {
 
-      var input, timeDate;
+      let input, timeDate;
 
       beforeEach(inject(function(elementRegistry, selection) {
 
         // given
-        var shape = elementRegistry.get('TIME_DATE');
+        const shape = elementRegistry.get('TIME_DATE');
         selection.select(shape);
 
-        var bo = getBusinessObject(shape);
-        var timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
+        const bo = getBusinessObject(shape);
+        const timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
         timeDate = timerDefinition.timeDate;
 
         input = getTimerDefinitionField(container);
@@ -802,16 +802,16 @@ describe('start-event-timer-event-properties', function() {
 
     describe('of time cycle', function() {
 
-      var input, timeCycle;
+      let input, timeCycle;
 
       beforeEach(inject(function(elementRegistry, selection) {
 
         // given
-        var shape = elementRegistry.get('TIME_CYCLE');
+        const shape = elementRegistry.get('TIME_CYCLE');
         selection.select(shape);
 
-        var bo = getBusinessObject(shape);
-        var timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
+        const bo = getBusinessObject(shape);
+        const timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
         timeCycle = timerDefinition.timeCycle;
 
         input = getTimerDefinitionField(container);
@@ -891,11 +891,11 @@ describe('start-event-timer-event-properties', function() {
     it('should set timer event definition field as invalid', inject(function(propertiesPanel, elementRegistry, selection) {
 
       // given
-      var shape = elementRegistry.get('TIME_CYCLE');
+      const shape = elementRegistry.get('TIME_CYCLE');
       selection.select(shape);
 
-      var container = propertiesPanel._container;
-      var input = getTimerDefinitionField(container);
+      const container = propertiesPanel._container;
+      const input = getTimerDefinitionField(container);
 
       // when
       triggerValue(input, '', 'change');

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/MultiInstanceProps.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/MultiInstanceProps.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import multiInstanceLoopCharacteristics from './implementation/MultiInstanceLoopCharacteristics';
+
+export default function(group, element, bpmnFactory, translate) {
+
+  if (!ensureMultiInstanceSupported(element)) {
+    return;
+  }
+
+  group.entries = group.entries.concat(multiInstanceLoopCharacteristics(element, bpmnFactory, translate));
+}
+
+// helpers //////////////
+
+function getLoopCharacteristics(element) {
+  const bo = getBusinessObject(element);
+  return bo.loopCharacteristics;
+}
+
+function ensureMultiInstanceSupported(element) {
+  return !!getLoopCharacteristics(element);
+}

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/TimerEventProps.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/TimerEventProps.js
@@ -37,7 +37,7 @@ export default function(group, element, bpmnFactory, options) {
 }
 
 function cancelActivity(element) {
-  var bo = getBusinessObject(element);
+  const bo = getBusinessObject(element);
   return bo.cancelActivity;
 }
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/InputOutput.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/InputOutput.js
@@ -58,6 +58,8 @@ function ensureInputparameterSupported(element) {
 export default function(element, bpmnFactory, options = {}) {
   const idPrefix = options.idPrefix || '';
 
+  let inputEntry, outputEntry;
+
   const getSelected = (element, node) => {
     let selection = (inputEntry && inputEntry.getSelected(element, node)) || { idx: -1 };
 
@@ -140,7 +142,7 @@ export default function(element, bpmnFactory, options = {}) {
 
   // input parameters ///////////////////////////////////////////////////////////////
   if (ensureInputparameterSupported(element)) {
-    var inputEntry = extensionElementsEntry(element, bpmnFactory, {
+    inputEntry = extensionElementsEntry(element, bpmnFactory, {
       id: `${idPrefix}inputs`,
       label: 'Input Parameters',
       modelProperty: 'source',
@@ -168,7 +170,7 @@ export default function(element, bpmnFactory, options = {}) {
   // output parameters ///////////////////////////////////////////////////////
 
   if (ensureOutparameterSupported(element)) {
-    var outputEntry = extensionElementsEntry(element, bpmnFactory, {
+    outputEntry = extensionElementsEntry(element, bpmnFactory, {
       id: `${idPrefix}outputs`,
       label: 'Output Parameters',
       modelProperty: 'source',

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/MultiInstanceLoopCharacteristics.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/MultiInstanceLoopCharacteristics.js
@@ -165,6 +165,6 @@ function getZeebeLoopCharacteristics(loopCharacteristics) {
 }
 
 function getLoopCharacteristics(element) {
-  var bo = getBusinessObject(element);
+  const bo = getBusinessObject(element);
   return bo.loopCharacteristics;
 }

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/MultiInstanceLoopCharacteristics.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/MultiInstanceLoopCharacteristics.js
@@ -1,0 +1,170 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import entryFactory from 'bpmn-js-properties-panel/lib/factory/EntryFactory';
+
+import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
+
+import cmdHelper from 'bpmn-js-properties-panel/lib/helper/CmdHelper';
+
+import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+
+export default function(element, bpmnFactory, translate) {
+
+  function getProperty(element, propertyName) {
+    const loopCharacteristics = getLoopCharacteristics(element),
+          zeebeLoopCharacteristics = getZeebeLoopCharacteristics(loopCharacteristics);
+
+    return zeebeLoopCharacteristics && zeebeLoopCharacteristics.get(propertyName);
+  }
+
+  function setProperties(element, values) {
+    const loopCharacteristics = getLoopCharacteristics(element),
+          commands = [];
+
+    // ensure extensionElements
+    let extensionElements = loopCharacteristics.get('extensionElements');
+    if (!extensionElements) {
+      extensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, loopCharacteristics, bpmnFactory);
+      commands.push(cmdHelper.updateBusinessObject(element, loopCharacteristics, { extensionElements: extensionElements }));
+    }
+
+    // ensure zeebe:LoopCharacteristics
+    let zeebeLoopCharacteristics = getZeebeLoopCharacteristics(loopCharacteristics);
+    if (!zeebeLoopCharacteristics) {
+      zeebeLoopCharacteristics = elementHelper.createElement('zeebe:LoopCharacteristics', { }, extensionElements, bpmnFactory);
+      commands.push(cmdHelper.addAndRemoveElementsFromList(
+        element,
+        extensionElements,
+        'values',
+        'extensionElements',
+        [ zeebeLoopCharacteristics ],
+        []
+      ));
+    }
+
+    commands.push(cmdHelper.updateBusinessObject(element, zeebeLoopCharacteristics, values));
+    return commands;
+  }
+
+  let entries = [];
+
+  // input collection //////////////////////////////////////////////////////////////
+  entries.push(entryFactory.textField({
+    id: 'multiInstance-inputCollection',
+    label: translate('Input Collection'),
+    modelProperty: 'inputCollection',
+
+    get: function(element) {
+
+      return {
+        inputCollection: getProperty(element, 'inputCollection')
+      };
+
+    },
+
+    set: setProperties,
+
+    validate: function(element, values) {
+      const loopCharacteristics = getLoopCharacteristics(element),
+            zeebeLoopCharacteristics = getZeebeLoopCharacteristics(loopCharacteristics);
+
+      let validation = {};
+      if (zeebeLoopCharacteristics) {
+        const {
+          inputCollection
+        } = values;
+
+        if (!inputCollection) {
+          validation = {
+            inputCollection: 'input collection must not be empty'
+          };
+        }
+      }
+      return validation;
+    }
+  }));
+
+  // input element //////////////////////////////////////////////////////////////////
+  entries.push(entryFactory.textField({
+    id: 'multiInstance-inputElement',
+    label: translate('Input Element'),
+    modelProperty: 'inputElement',
+
+    get: function(element) {
+
+      return {
+        inputElement: getProperty(element, 'inputElement')
+      };
+
+    },
+
+    set: setProperties
+  }));
+
+  // output collection ////////////////////////////////////////////////////////////
+  entries.push(entryFactory.textField({
+    id: 'multiInstance-outputCollection',
+    label: translate('Output Collection'),
+    modelProperty: 'outputCollection',
+
+    get: function(element) {
+
+      return {
+        outputCollection: getProperty(element, 'outputCollection')
+      };
+
+    },
+
+    set: setProperties
+  }));
+
+  // output element //////////////////////////////////////////////////////
+  entries.push(entryFactory.textField({
+    id: 'multiInstance-outputElement',
+    label: translate('Output Element'),
+    modelProperty: 'outputElement',
+
+    get: function(element) {
+
+      return {
+        outputElement: getProperty(element, 'outputElement')
+      };
+
+    },
+
+    set: setProperties
+  }));
+
+  return entries;
+
+}
+
+// helper /////////
+
+function getExtensionElements(bo, type, prop) {
+  const elements = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  return !prop ? elements : (elements[0] || {})[prop] || [];
+}
+
+function getZeebeLoopCharacteristics(loopCharacteristics) {
+  const extensionElements = getExtensionElements(loopCharacteristics, 'zeebe:LoopCharacteristics');
+
+  return extensionElements && extensionElements[0];
+}
+
+function getLoopCharacteristics(element) {
+  var bo = getBusinessObject(element);
+  return bo.loopCharacteristics;
+}

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/PayloadMappings.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/PayloadMappings.js
@@ -46,6 +46,8 @@ function ensurePayloadMappingsSupported(element) {
 export default function(element, bpmnFactory, options = {}) {
   const idPrefix = options.idPrefix || '';
 
+  let inputEntry;
+
   const getSelected = (element, node) => {
     const selection = (inputEntry && inputEntry.getSelected(element, node)) || { idx: -1 };
     const parameter = getMapping(element, selection.idx);
@@ -121,7 +123,7 @@ export default function(element, bpmnFactory, options = {}) {
 
   // input parameters ///////////////////////////////////////////////////////////////
 
-  var inputEntry = extensionElementsEntry(element, bpmnFactory, {
+  inputEntry = extensionElementsEntry(element, bpmnFactory, {
     id: `${idPrefix}inputs`,
     label: 'Input Parameters',
     modelProperty: 'source',

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/TimerEventDefinition.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/TimerEventDefinition.js
@@ -22,17 +22,17 @@ import entryFactory from 'bpmn-js-properties-panel/lib/factory/EntryFactory';
  * @return {string|undefined} the timer definition type
  */
 function getTimerDefinitionType(timer) {
-  var timeDate = timer.get('timeDate');
+  const timeDate = timer.get('timeDate');
   if (typeof timeDate !== 'undefined') {
     return 'timeDate';
   }
 
-  var timeCycle = timer.get('timeCycle');
+  const timeCycle = timer.get('timeCycle');
   if (typeof timeCycle !== 'undefined') {
     return 'timeCycle';
   }
 
-  var timeDuration = timer.get('timeDuration');
+  const timeDuration = timer.get('timeDuration');
   if (typeof timeDuration !== 'undefined') {
     return 'timeDuration';
   }
@@ -56,7 +56,7 @@ export default class TimerEventDefinition {
 
   constructor(group, element, bpmnFactory, timerEventDefinition, timerOptions) {
 
-    var selectOptions = timerOptions;
+    const selectOptions = timerOptions;
 
     group.entries.push(entryFactory.selectBox({
       id: 'timer-event-definition-type',
@@ -72,19 +72,19 @@ export default class TimerEventDefinition {
       },
 
       set: function(element, values) {
-        var props = {
+        const props = {
           timeDuration: undefined,
           timeDate: undefined,
           timeCycle: undefined
         };
 
-        var newType = values.timerDefinitionType;
+        const newType = values.timerDefinitionType;
         if (values.timerDefinitionType) {
-          var oldType = getTimerDefinitionType(timerEventDefinition);
+          const oldType = getTimerDefinitionType(timerEventDefinition);
 
-          var value;
+          let value;
           if (oldType) {
-            var definition = timerEventDefinition.get(oldType);
+            const definition = timerEventDefinition.get(oldType);
             value = definition.get('body');
           }
 
@@ -102,17 +102,17 @@ export default class TimerEventDefinition {
       modelProperty: 'timerDefinition',
 
       get: function(element, node) {
-        var type = getTimerDefinitionType(timerEventDefinition);
-        var definition = type && timerEventDefinition.get(type);
-        var value = definition && definition.get('body');
+        const type = getTimerDefinitionType(timerEventDefinition);
+        const definition = type && timerEventDefinition.get(type);
+        const value = definition && definition.get('body');
         return {
           timerDefinition: value
         };
       },
 
       set: function(element, values) {
-        var type = getTimerDefinitionType(timerEventDefinition);
-        var definition = type && timerEventDefinition.get(type);
+        const type = getTimerDefinitionType(timerEventDefinition);
+        const definition = type && timerEventDefinition.get(type);
 
         if (definition) {
           return cmdHelper.updateBusinessObject(element, definition, {
@@ -122,10 +122,10 @@ export default class TimerEventDefinition {
       },
 
       validate: function(element) {
-        var type = getTimerDefinitionType(timerEventDefinition);
-        var definition = type && timerEventDefinition.get(type);
+        const type = getTimerDefinitionType(timerEventDefinition);
+        const definition = type && timerEventDefinition.get(type);
         if (definition) {
-          var value = definition.get('body');
+          const value = definition.get('body');
           if (!value) {
             return {
               timerDefinition: 'Must provide a value'

--- a/client/src/app/tabs/bpmn/custom/zeebe-bpmn-moddle/zeebe.json
+++ b/client/src/app/tabs/bpmn/custom/zeebe-bpmn-moddle/zeebe.json
@@ -162,6 +162,41 @@
           "isAttr": true
         }
       ]
+    },
+    {
+      "name": "LoopCharacteristics",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:ServiceTask",
+          "bpmn:ReceiveTask",
+          "bpmn:SubProcess"
+        ]
+      },
+      "properties": [
+        {
+          "name": "inputCollection",
+          "type": "string",
+          "isAttr": true
+        },
+        {
+          "name": "inputElement",
+          "type": "string",
+          "isAttr": true
+        },
+        {
+          "name": "outputCollection",
+          "type": "string",
+          "isAttr": true
+        },
+        {
+          "name": "outputElement",
+          "type": "string",
+          "isAttr": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #82

This adds support to annotate `bpmn:ServiceTask`, `bpmn:ReceiveTask` and `bpmn:SubProcess` elements with the multi-instance marker. It also adds the related Zeebe properties to the provider. As discussed with the @saig0, the `inputCollection` property is configured as _required_.

![Kapture 2019-09-04 at 13 20 25](https://user-images.githubusercontent.com/9433996/64250591-ce5de180-cf16-11e9-9c1c-1e29604fdad7.gif)


 