### PR TITLE
fix(client/properties-provider): fix validation for task definition type

### DIFF
--- a/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
@@ -70,7 +70,7 @@ function createGeneralTabGroups(element, bpmnFactory, canvas, translate) {
   idProps(generalGroup, element, translate);
   nameProps(generalGroup, element, bpmnFactory, canvas, translate);
   executableProps(generalGroup, element, translate);
-  taskDefinition(generalGroup, element, bpmnFactory);
+  taskDefinition(generalGroup, element, bpmnFactory, translate);
   sequenceFlowProps(generalGroup, element, bpmnFactory, translate);
   messageProps(generalGroup, element, bpmnFactory, translate);
   timerProps(generalGroup, element, bpmnFactory, translate);

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/TaskDefinitionSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/TaskDefinitionSpec.js
@@ -22,6 +22,7 @@ import TestContainer from 'mocha-test-container-support';
 import propertiesPanelModule from 'bpmn-js-properties-panel';
 
 import {
+  classes as domClasses,
   query as domQuery
 } from 'min-dom';
 
@@ -219,6 +220,44 @@ describe('customs - task definition properties', function() {
 
     });
 
+
+    describe('set task definition type field as invalid', function() {
+
+      let input;
+
+      beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+        const shape = elementRegistry.get('Task_1');
+        selection.select(shape);
+
+        const container = propertiesPanel._container;
+        input = getInputField(container, 'camunda-taskDefinitionType', 'type');
+
+        // ensure task definition is created
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      it('on empty value', function() {
+
+        // when
+        triggerValue(input, '', 'change');
+
+        // then
+        expect(isInputInvalid(input)).to.be.true;
+      });
+
+
+      it('on spaces', function() {
+
+        // when
+        triggerValue(input, 'foo bar', 'change');
+
+        // then
+        expect(isInputInvalid(input)).to.be.true;
+      });
+
+    });
+
   });
 
 
@@ -391,3 +430,7 @@ const getInputField = (container, entryId, inputName) => {
   const selector = 'input' + (inputName ? '[name="' + inputName + '"]' : '');
   return domQuery(selector, getEntry(container, entryId));
 };
+
+function isInputInvalid(node) {
+  return domClasses(node).has('invalid');
+}

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/TaskDefinitionProps.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/TaskDefinitionProps.js
@@ -17,13 +17,15 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import utils from 'bpmn-js-properties-panel/lib/Utils';
+import {
+  containsSpace
+} from 'bpmn-js-properties-panel/lib/Utils';
 
 import entryFactory from 'bpmn-js-properties-panel/lib/factory/EntryFactory';
 
 import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
 
-export default function(group, element, bpmnFactory) {
+export default function(group, element, bpmnFactory, translate) {
 
   if (!is(element, 'bpmn:ServiceTask')) {
     return;
@@ -41,18 +43,18 @@ export default function(group, element, bpmnFactory) {
 
   group.entries.push(entryFactory.validationAwareTextField({
     id: 'taskDefinitionType',
-    label: 'Type',
+    label: translate('Type'),
     modelProperty: 'type',
 
     getProperty: function(element, node) {
-      return (getTaskDefinition(element, node) || {}).type;
+      return (getTaskDefinition(element) || {}).type;
     },
 
     setProperty: function(element, values, node) {
       const bo = getBusinessObject(element);
       const commands = [];
 
-      // CREATE extensionElements
+      // create extensionElements
       let extensionElements = bo.get('extensionElements');
       if (!extensionElements) {
         extensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, bo, bpmnFactory);
@@ -79,38 +81,46 @@ export default function(group, element, bpmnFactory) {
     },
 
     validate: function(element, values, node) {
-      const bo = getTaskDefinition(element, node);
-      const validation = {};
+      const bo = getTaskDefinition(element);
+      let validation = {};
       if (bo) {
-        const sourceValue = values.source;
+        const {
+          type
+        } = values;
 
-        if (sourceValue) {
-          if (utils.containsSpace(sourceValue)) {
-            validation.source = 'Type must not contain spaces';
+        if (type) {
+          if (containsSpace(type)) {
+            validation = {
+              type: 'Type must not contain spaces'
+            };
           }
         }
         else {
-          validation.source = 'ServiceTask must have a type';
+          validation = {
+            type: 'ServiceTask must have a type'
+          };
         }
       }
       return validation;
     }
   }));
 
-  group.entries.push(entryFactory.validationAwareTextField({
+  group.entries.push(entryFactory.textField({
     id: 'taskDefinitionRetries',
-    label: 'Retries',
+    label: translate('Retries'),
     modelProperty: 'retries',
 
-    getProperty: function(element, node) {
-      return (getTaskDefinition(element, node) || {}).retries;
+    get: function(element) {
+      return {
+        retries: (getTaskDefinition(element) || {}).retries
+      };
     },
 
-    setProperty: function(element, values, node) {
+    set: function(element, values) {
       const bo = getBusinessObject(element);
       const commands = [];
 
-      // CREATE extensionElements
+      // create extensionElements
       let extensionElements = bo.get('extensionElements');
       if (!extensionElements) {
         extensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, bo, bpmnFactory);
@@ -134,11 +144,6 @@ export default function(group, element, bpmnFactory) {
 
       commands.push(cmdHelper.updateBusinessObject(element, taskDefinition, values));
       return commands;
-    },
-
-    validate: function(element, values, node) {
-
-      return true;
     }
 
   }));


### PR DESCRIPTION
I found out that the input validation for the task definition type property isn't working currently as expected. This fixes it.

![Kapture 2019-09-04 at 13 31 27](https://user-images.githubusercontent.com/9433996/64251241-51cc0280-cf18-11e9-990c-761b41c66e20.gif)
