### PR TITLE
feat(client): error boundary event support

### DIFF
--- a/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
+++ b/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
@@ -28,7 +28,8 @@ export const AVAILABLE_REPLACE_ELEMENTS = [
   'replace-with-message-start',
   'replace-with-timer-start',
   'replace-with-non-interrupting-message-boundary',
-  'replace-with-non-interrupting-timer-boundary'
+  'replace-with-non-interrupting-timer-boundary',
+  'replace-with-error-boundary'
 ];
 
 export const AVAILABLE_CONTEXTPAD_ENTRIES = [

--- a/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
@@ -40,6 +40,9 @@ import payloadMappingsProps from './parts/PayloadMappingsProps';
 
 import multiInstanceProps from './parts/MultiInstanceProps';
 
+import errorProps from './parts/ErrorProps';
+
+
 const getInputOutputParameterLabel = param => {
 
   if (is(param, 'zeebe:InputParameter')) {
@@ -76,6 +79,7 @@ function createGeneralTabGroups(element, bpmnFactory, canvas, translate) {
   sequenceFlowProps(generalGroup, element, bpmnFactory, translate);
   messageProps(generalGroup, element, bpmnFactory, translate);
   timerProps(generalGroup, element, bpmnFactory, translate);
+  errorProps(generalGroup, element, bpmnFactory, translate);
 
   const multiInstanceGroup = {
     id: 'multiInstance',

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/Error.bpmn
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/Error.bpmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_04vgx99" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.3.2">
+  <bpmn:process id="Process_01mwz8c" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1rmcgi7" />
+    <bpmn:boundaryEvent id="BoundaryErrorEvent" name="BoundaryErrorEvent" attachedToRef="SubProcess_1rmcgi7">
+      <bpmn:errorEventDefinition errorRef="Error_0slq64n" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmn:error id="Error_1scwdln" name="Error1" errorCode="code1" />
+  <bpmn:error id="Error_0slq64n" name="Error2" errorCode="code2" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_01mwz8c">
+      <bpmndi:BPMNShape id="SubProcess_1rmcgi7_di" bpmnElement="SubProcess_1rmcgi7" isExpanded="true">
+        <dc:Bounds x="160" y="100" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_06tl39v_di" bpmnElement="BoundaryErrorEvent">
+        <dc:Bounds x="492" y="282" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="468" y="325" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/ErrorSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/ErrorSpec.js
@@ -1,0 +1,652 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  bootstrapModeler,
+  inject
+} from 'bpmn-js/test/helper';
+
+import {
+  triggerValue,
+  triggerEvent,
+  selectedByOption
+} from './helper';
+
+import TestContainer from 'mocha-test-container-support';
+
+import propertiesPanelModule from 'bpmn-js-properties-panel';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import eventDefinitionHelper from 'bpmn-js-properties-panel/lib/helper/EventDefinitionHelper';
+
+import coreModule from 'bpmn-js/lib/core';
+import selectionModule from 'diagram-js/lib/features/selection';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import propertiesProviderModule from '../';
+import zeebeModdleExtensions from '../../zeebe-bpmn-moddle/zeebe';
+
+describe('customs - error properties', function() {
+
+  const diagramXML = require('./Error.bpmn');
+
+  const testModules = [
+    coreModule, selectionModule, modelingModule,
+    propertiesPanelModule,
+    propertiesProviderModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container, errorEventDefinition;
+
+  beforeEach(function() {
+
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapModeler(diagramXML, {
+
+    modules: testModules,
+    moddleExtensions
+  }));
+
+
+  beforeEach(inject(function(commandStack, propertiesPanel) {
+
+    const undoButton = document.createElement('button');
+    undoButton.textContent = 'UNDO';
+
+    undoButton.addEventListener('click', () => {
+      commandStack.undo();
+    });
+
+    container.appendChild(undoButton);
+
+    propertiesPanel.attachTo(container);
+  }));
+
+  describe('get', function() {
+
+    beforeEach(inject(function(elementRegistry, propertiesPanel, selection) {
+
+      container = propertiesPanel._container;
+
+      let shape = elementRegistry.get('BoundaryErrorEvent');
+      selection.select(shape);
+
+      let bo = getBusinessObject(shape);
+      errorEventDefinition = eventDefinitionHelper.getErrorEventDefinition(bo);
+
+    }));
+
+    describe('should get the Error Name', function() {
+
+      let field;
+
+      beforeEach(function() {
+
+        field = getInputField(container, 'camunda-error-element-name', 'name');
+
+      });
+
+      it('in the DOM', function() {
+
+        expect(field.value).to.equal('Error2');
+
+      });
+
+
+      it('on the business object', function() {
+
+        expect(errorEventDefinition.errorRef.name).to.equal('Error2');
+
+      });
+
+    });
+
+
+    describe('should get the Error Code', function() {
+
+      let field;
+
+      beforeEach(function() {
+
+        field = getInputField(container, 'camunda-error-element-code', 'errorCode');
+
+      });
+
+      it('in the DOM', function() {
+
+        expect(field.value).to.equal('code2');
+
+      });
+
+
+      it('on the business object', function() {
+
+        expect(errorEventDefinition.errorRef.errorCode).to.equal('code2');
+
+      });
+
+    });
+
+  });
+
+
+  describe('set', function() {
+
+    describe('should set the Error Name', function() {
+
+      let field;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        let item = elementRegistry.get('BoundaryErrorEvent');
+        selection.select(item);
+
+        let businessObject = item.businessObject;
+        errorEventDefinition = eventDefinitionHelper.getErrorEventDefinition(businessObject);
+
+        field = getInputField(container, 'camunda-error-element-name', 'name');
+
+        triggerValue(field, 'FOO', 'change');
+
+      }));
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          expect(field.value).to.equal('FOO');
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(field.value).to.equal('Error2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+
+          expect(field.value).to.equal('FOO');
+
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should execute', function() {
+
+          expect(errorEventDefinition.errorRef.name).to.equal('FOO');
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(errorEventDefinition.errorRef.name).to.equal('Error2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+
+          expect(errorEventDefinition.errorRef.name).to.equal('FOO');
+
+        }));
+
+      });
+
+    });
+
+
+    describe('should set the Error Code', function() {
+
+      let errorEventDefinition, field;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        let item = elementRegistry.get('BoundaryErrorEvent');
+        selection.select(item);
+
+        let businessObject = item.businessObject;
+        errorEventDefinition = eventDefinitionHelper.getErrorEventDefinition(businessObject);
+
+        field = getInputField(container, 'camunda-error-element-code', 'errorCode');
+
+        triggerValue(field, 'FOO', 'change');
+
+      }));
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          expect(field.value).to.equal('FOO');
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(field.value).to.equal('code2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+          expect(field.value).to.equal('FOO');
+
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should execute', function() {
+
+          expect(errorEventDefinition.errorRef.errorCode).to.equal('FOO');
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(errorEventDefinition.errorRef.errorCode).to.equal('code2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+          expect(errorEventDefinition.errorRef.errorCode).to.equal('FOO');
+
+        }));
+
+      });
+
+    });
+
+  });
+
+
+  describe('remove', function() {
+
+    beforeEach(inject(function(elementRegistry, propertiesPanel, selection) {
+
+      container = propertiesPanel._container;
+
+      let shape = elementRegistry.get('BoundaryErrorEvent');
+      selection.select(shape);
+
+      let businessObject = getBusinessObject(shape);
+      errorEventDefinition = eventDefinitionHelper.getErrorEventDefinition(businessObject);
+
+    }));
+
+    describe('should remove the Error Name', function() {
+
+      let field, button;
+
+      beforeEach(function() {
+
+        field = getInputField(container, 'camunda-error-element-name', 'name');
+        button = getClearButton(container, 'error-element-name');
+
+        triggerEvent(button, 'click');
+
+      });
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          expect(field.value).is.empty;
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(field.value).to.equal('Error2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+          expect(field.value).is.empty;
+
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should execute', function() {
+
+          expect(errorEventDefinition.errorRef.name).to.be.undefined;
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(errorEventDefinition.errorRef.name).to.equal('Error2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+          expect(errorEventDefinition.errorRef.name).to.be.undefined;
+
+        }));
+
+      });
+
+    });
+
+
+    describe('should remove the Error Code', function() {
+
+      let field, button;
+
+      beforeEach(function() {
+
+        field = getInputField(container, 'camunda-error-element-code', 'errorCode');
+        button = getClearButton(container, 'error-element-code');
+
+        triggerEvent(button, 'click');
+
+      });
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          expect(field.value).is.empty;
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(field.value).to.equal('code2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+          expect(field.value).is.empty;
+
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should execute', function() {
+
+          expect(errorEventDefinition.errorRef.errorCode).to.be.undefined;
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(errorEventDefinition.errorRef.errorCode).to.equal('code2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+          expect(errorEventDefinition.errorRef.errorCode).to.be.undefined;
+
+        }));
+
+      });
+
+    });
+
+  });
+
+
+  describe('switch', function() {
+
+    beforeEach(inject(function(elementRegistry, propertiesPanel, selection) {
+
+      container = propertiesPanel._container;
+
+      let shape = elementRegistry.get('BoundaryErrorEvent');
+      selection.select(shape);
+
+      let businessObject = getBusinessObject(shape);
+      errorEventDefinition = eventDefinitionHelper.getErrorEventDefinition(businessObject);
+
+      let selectField = getSelectField(container, 'event-definitions-error', 'selectedElement');
+      selectedByOption(selectField, 'Error_1scwdln');
+      triggerEvent(selectField, 'change');
+
+    }));
+
+    describe('should switch the Error Name', function() {
+
+      let field;
+
+      beforeEach(inject(function(elementRegistry, propertiesPanel, selection) {
+
+        field = getInputField(container, 'camunda-error-element-name', 'name');
+
+      }));
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          expect(field.value).to.equal('Error1');
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(field.value).to.equal('Error2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+          expect(field.value).to.equal('Error1');
+
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should execute', function() {
+
+          expect(errorEventDefinition.errorRef.name).to.equal('Error1');
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(errorEventDefinition.errorRef.name).to.equal('Error2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+          expect(errorEventDefinition.errorRef.name).to.equal('Error1');
+
+        }));
+
+      });
+
+    });
+
+
+    describe('should switch the Error Code', function() {
+
+      let field;
+
+      beforeEach(inject(function(elementRegistry, propertiesPanel, selection) {
+
+        field = getInputField(container, 'camunda-error-element-code', 'errorCode');
+
+      }));
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          expect(field.value).to.equal('code1');
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(field.value).to.equal('code2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+          expect(field.value).to.equal('code1');
+
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should execute', function() {
+
+          expect(errorEventDefinition.errorRef.errorCode).to.equal('code1');
+
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          commandStack.undo();
+          expect(errorEventDefinition.errorRef.errorCode).to.equal('code2');
+
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          commandStack.undo();
+          commandStack.redo();
+          expect(errorEventDefinition.errorRef.errorCode).to.equal('code1');
+
+        }));
+
+      });
+
+    });
+
+  });
+
+});
+
+// helper /////////
+
+const getGeneralTab = (container) => {
+  return domQuery('div[data-tab="general"]', container);
+};
+
+const getDetailsGroup = (container) => {
+  const tab = getGeneralTab(container);
+  return domQuery('div[data-group="details"]', tab);
+};
+
+const getEntry = (container, entryId) => {
+  return domQuery('div[data-entry="' + entryId + '"]', getDetailsGroup(container));
+};
+
+const getInputField = (container, entryId, inputName) => {
+  const selector = 'input' + (inputName ? '[name="' + inputName + '"]' : '');
+  return domQuery(selector, getEntry(container, entryId));
+};
+
+const getClearButton = (container, selector) => {
+  return domQuery('div[data-entry=' + selector + '] button[data-action=clear]', container);
+};
+
+const getSelectField = (container, entryId, selectName) => {
+  var selector = 'select' + (selectName ? '[name="' + selectName + '"]' : '');
+  return domQuery(selector, getEntry(container, entryId));
+};

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/ErrorProps.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/ErrorProps.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import eventDefinitionHelper from 'bpmn-js-properties-panel/lib/helper/EventDefinitionHelper';
+
+import error from 'bpmn-js-properties-panel/lib/provider/bpmn/parts/implementation/ErrorEventDefinition';
+
+export default function(group, element, bpmnFactory, translate) {
+
+  const errorEventDefinition = eventDefinitionHelper.getErrorEventDefinition(element);
+
+  if (errorEventDefinition) {
+    error(group, element, bpmnFactory, errorEventDefinition, translate);
+  }
+
+}


### PR DESCRIPTION
Fixes #85 

This pr adds Error Boundary Event into replace menu. 40 tests implemented to cover get/set/remove/switch-between-error-events cases.

 
![Kapture 2019-09-04 at 16 18 57](https://user-images.githubusercontent.com/15003836/64263319-c0688a80-cf2f-11e9-870b-56690bf8d71f.gif)

