### PR TITLE
Refactor Zeebe customs

### DIFF
--- a/client/src/app/tabs/bpmn/custom/__tests__/CustomPaletteProviderSpec.js
+++ b/client/src/app/tabs/bpmn/custom/__tests__/CustomPaletteProviderSpec.js
@@ -10,8 +10,18 @@
 
 import {
   bootstrapModeler,
+  getBpmnJS,
   inject
 } from 'bpmn-js/test/helper';
+
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  createMoveEvent
+} from 'diagram-js/lib/features/mouse/Mouse';
 
 import {
   query as domQuery,
@@ -39,7 +49,7 @@ describe('customs - palette', function() {
 
   beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
 
-  it('should provide zeebe related entries', inject(function(canvas, palette) {
+  it('should provide zeebe related entries', inject(function(canvas) {
 
     // when
     const paletteElement = domQuery('.djs-palette', canvas._container);
@@ -47,8 +57,143 @@ describe('customs - palette', function() {
 
     // then
     expect(entries.length).to.equal(12);
-
   }));
 
 
+  it('should create start event', inject(function(dragging) {
+
+    // when
+    triggerPaletteEntry('create.start-event');
+
+    // then
+    const context = dragging.context(),
+          elements = context.data.elements;
+
+    expect(elements).to.exist;
+    expect(is(elements[0], 'bpmn:StartEvent')).to.be.true;
+  }));
+
+
+  it('should create end task', inject(function(dragging) {
+
+    // when
+    triggerPaletteEntry('create.end-event');
+
+    // then
+    const context = dragging.context(),
+          elements = context.data.elements;
+
+    expect(elements).to.exist;
+    expect(is(elements[0], 'bpmn:EndEvent')).to.be.true;
+  }));
+
+
+  it('should create service task', inject(function(dragging) {
+
+    // when
+    triggerPaletteEntry('create.service-task');
+
+    // then
+    const context = dragging.context(),
+          elements = context.data.elements;
+
+    expect(elements).to.exist;
+    expect(is(elements[0], 'bpmn:ServiceTask')).to.be.true;
+  }));
+
+
+  it('should create receive task', inject(function(dragging) {
+
+    // when
+    triggerPaletteEntry('create.receive-task');
+
+    // then
+    const context = dragging.context(),
+          elements = context.data.elements;
+
+    expect(elements).to.exist;
+    expect(is(elements[0], 'bpmn:ReceiveTask')).to.be.true;
+  }));
+
+
+  it('should create subprocess (expanded)', inject(function(dragging) {
+
+    // when
+    triggerPaletteEntry('create.subprocess-expanded');
+
+    // then
+    const context = dragging.context(),
+          elements = context.data.elements,
+          element = elements[0],
+          bo = getBusinessObject(element);
+
+    expect(element).to.exist;
+    expect(is(element, 'bpmn:SubProcess')).to.be.true;
+    expect(bo.di.isExpanded).to.be.true;
+  }));
+
+
+  it('should intermediate catch message event', inject(function(dragging) {
+
+    // when
+    triggerPaletteEntry('create.intermediate-catch-message-event');
+
+    // then
+    const context = dragging.context(),
+          elements = context.data.elements,
+          element = elements[0],
+          bo = getBusinessObject(element),
+          eventDefinitions = bo.eventDefinitions;
+
+    expect(element).to.exist;
+    expect(is(element, 'bpmn:IntermediateCatchEvent')).to.be.true;
+    expect(eventDefinitions).to.exist;
+    expect(eventDefinitions[0].$type).to.equal('bpmn:MessageEventDefinition');
+  }));
+
+
+  it('should intermediate catch timer event', inject(function(dragging) {
+
+    // when
+    triggerPaletteEntry('create.intermediate-catch-timer-event');
+
+    // then
+    const context = dragging.context(),
+          elements = context.data.elements,
+          element = elements[0],
+          bo = getBusinessObject(element),
+          eventDefinitions = bo.eventDefinitions;
+
+    expect(element).to.exist;
+    expect(is(element, 'bpmn:IntermediateCatchEvent')).to.be.true;
+    expect(eventDefinitions).to.exist;
+    expect(eventDefinitions[0].$type).to.equal('bpmn:TimerEventDefinition');
+  }));
+
+
+  it('should create exclusive gateway', inject(function(dragging) {
+
+    // when
+    triggerPaletteEntry('create.exclusive-gateway');
+
+    // then
+    const context = dragging.context(),
+          elements = context.data.elements;
+
+    expect(elements).to.exist;
+    expect(is(elements[0], 'bpmn:ExclusiveGateway')).to.be.true;
+  }));
+
 });
+
+// helper //////////
+
+function triggerPaletteEntry(id) {
+  getBpmnJS().invoke(function(palette) {
+    var entry = palette.getEntries()[ id ];
+
+    if (entry && entry.action && entry.action.click) {
+      entry.action.click(createMoveEvent(0, 0));
+    }
+  });
+}

--- a/client/src/app/tabs/bpmn/custom/modeling/__tests__/CreateZeebeBoundaryEventBehaviorSpec.js
+++ b/client/src/app/tabs/bpmn/custom/modeling/__tests__/CreateZeebeBoundaryEventBehaviorSpec.js
@@ -62,8 +62,34 @@ describe('features/modeling/behavior - create boundary events', function() {
     expect(newEvent.type).to.equal('bpmn:BoundaryEvent');
     expect(newEvent.businessObject.attachedToRef).to.equal(task.businessObject);
     expect(newEvent.businessObject.eventDefinitions[0]).to.not.be.null;
-
   }));
+
+
+  it('should execute on attach (without event definition)', inject(
+    function(canvas, elementFactory, modeling, bpmnFactory) {
+
+      // given
+      const messageIntermediateCatchEvent = bpmnFactory.create('bpmn:IntermediateCatchEvent');
+
+      const intermediateEvent = elementFactory.create('shape', {
+        id: messageIntermediateCatchEvent.id,
+        businessObject: messageIntermediateCatchEvent
+      });
+
+      const rootElement = canvas.getRootElement(),
+            task = elementFactory.createShape({ type: 'bpmn:Task' });
+
+      modeling.createShape(task, { x: 100, y: 100 }, rootElement);
+
+      // when
+      const newEvent = modeling.createShape(intermediateEvent, { x: 50 + 15, y: 100 }, task, { attach: true });
+
+      // then
+      expect(newEvent.type).to.equal('bpmn:BoundaryEvent');
+      expect(newEvent.businessObject.attachedToRef).to.equal(task.businessObject);
+      expect(newEvent.businessObject.eventDefinitions).to.be.undefined;
+    }
+  ));
 
 
   it('should NOT execute on drop', inject(function(canvas, elementFactory, modeling) {
@@ -72,7 +98,6 @@ describe('features/modeling/behavior - create boundary events', function() {
     const rootElement = canvas.getRootElement(),
           subProcess = elementFactory.createShape({ type: 'bpmn:SubProcess', isExpanded: true }),
           intermediateEvent = elementFactory.createShape({ type: 'bpmn:IntermediateCatchEvent' });
-
 
     modeling.createShape(subProcess, { x: 300, y: 200 }, rootElement);
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutput.bpmn
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutput.bpmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.7.0-dev">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="inputSourceValue1" target="inputTargetValue1" />
+          <zeebe:input source="inputSourceValue2" target="inputTargetValue2" />
+          <zeebe:input source="inputSourceValue3" target="inputTargetValue3" />
+          <zeebe:input source="inputSourceValue4" target="inputTargetValue4" />
+          <zeebe:output source="outputSourceValue1" target="outputTargetValue1" />
+          <zeebe:output source="outputSourceValue2" target="outputTargetValue2" />
+          <zeebe:output source="outputSourceValue3" target="outputTargetValue3" />
+          <zeebe:output source="outputSourceValue4" target="outputTargetValue4" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_empty" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="ServiceTask_0rud1s3_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0td0iog_di" bpmnElement="ServiceTask_empty">
+        <dc:Bounds x="320" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutputSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutputSpec.js
@@ -1,0 +1,986 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  bootstrapModeler,
+  inject
+} from 'bpmn-js/test/helper';
+
+import {
+  triggerEvent,
+  triggerValue
+} from './helper';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import TestContainer from 'mocha-test-container-support';
+
+import propertiesPanelModule from 'bpmn-js-properties-panel';
+
+import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+
+import {
+  classes as domClasses,
+  query as domQuery
+} from 'min-dom';
+
+import coreModule from 'bpmn-js/lib/core';
+import selectionModule from 'diagram-js/lib/features/selection';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import propertiesProviderModule from '..';
+import zeebeModdleExtensions from '../../zeebe-bpmn-moddle/zeebe';
+
+describe('customs - input output property tab', function() {
+
+  const diagramXML = require('./InputOutput.bpmn');
+
+  const testModules = [
+    coreModule, selectionModule, modelingModule,
+    propertiesPanelModule,
+    propertiesProviderModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+
+  beforeEach(inject(function(commandStack, propertiesPanel) {
+
+    const undoButton = document.createElement('button');
+    undoButton.textContent = 'UNDO';
+
+    undoButton.addEventListener('click', () => {
+      commandStack.undo();
+    });
+
+    container.appendChild(undoButton);
+
+    propertiesPanel.attachTo(container);
+  }));
+
+  it('should fetch empty list of input and output parameters', inject(function(propertiesPanel, selection, elementRegistry) {
+
+    // given
+    const shape = elementRegistry.get('ServiceTask_empty');
+    const bo = getBusinessObject(shape);
+
+    // assume
+    expect(getInputParameters(bo).length).to.equal(0);
+    expect(getOutputParameters(bo).length).to.equal(0);
+
+    // when
+    selection.select(shape);
+
+    // then
+    const inputsSelection = getInputParameterSelect(propertiesPanel._container);
+    expect(inputsSelection.options.length).to.equal(0);
+
+    const outputsSelection = getOutputParameterSelect(propertiesPanel._container);
+    expect(outputsSelection.options.length).to.equal(0);
+  }));
+
+
+  it('should fetch list of input parameters', inject(function(propertiesPanel, selection, elementRegistry) {
+
+    // given
+    const shape = elementRegistry.get('ServiceTask_1');
+    const bo = getBusinessObject(shape);
+
+    // assume
+    expect(getInputParameters(bo).length).to.equal(4);
+
+    // when
+    selection.select(shape);
+
+    // then
+    const inputsSelection = getInputParameterSelect(propertiesPanel._container);
+    expect(inputsSelection.options.length).to.equal(4);
+  }));
+
+
+  it('should fetch list of output parameters', inject(function(propertiesPanel, selection, elementRegistry) {
+
+    // given
+    const shape = elementRegistry.get('ServiceTask_1');
+    const bo = getBusinessObject(shape);
+
+    // assume
+    expect(getOutputParameters(bo).length).to.equal(4);
+
+    // when
+    selection.select(shape);
+
+    // then
+    const outputsSelection = getOutputParameterSelect(propertiesPanel._container);
+    expect(outputsSelection.options.length).to.equal(4);
+  }));
+
+
+  describe('property controls', function() {
+
+    let container;
+
+    beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+      // given
+      container = propertiesPanel._container;
+      const shape = elementRegistry.get('ServiceTask_1');
+      selection.select(shape);
+
+    }));
+
+    describe('of input parameters', function() {
+
+      it('should fetch source property', function() {
+
+        // when
+        selectInputParameter(0, container);
+
+        // then
+        expect(getParameterSourceInput(container).value).to.equal('inputSourceValue1');
+      });
+
+
+      it('should fetch target property', function() {
+
+        // when
+        selectInputParameter(0, container);
+
+        // then
+        expect(getParameterTargetInput(container).value).to.equal('inputTargetValue1');
+      });
+
+    });
+
+
+    describe('of output parameters', function() {
+
+      it('should fetch source property', function() {
+
+        // when
+        selectOutputParameter(0, container);
+
+        // then
+        expect(getParameterSourceInput(container).value).to.equal('outputSourceValue1');
+      });
+
+
+      it('should fetch target property', function() {
+
+        // when
+        selectOutputParameter(0, container);
+
+        // then
+        expect(getParameterTargetInput(container).value).to.equal('outputTargetValue1');
+      });
+
+    });
+
+  });
+
+
+  describe('add input parameter', function() {
+
+    let bo;
+
+    beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+      // given
+      const container = propertiesPanel._container;
+
+      const shape = elementRegistry.get('ServiceTask_empty');
+      selection.select(shape);
+
+      bo = getBusinessObject(shape);
+
+      // when
+      clickAddInputParameterButton(container);
+
+    }));
+
+
+    describe('on the business object', function() {
+
+      it('should execute', function() {
+
+        // then
+        expect(getInputParameters(bo).length).to.equal(1);
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getInputParameters(bo).length).to.equal(0);
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getInputParameters(bo).length).to.equal(1);
+      }));
+
+    });
+
+
+    describe('in the DOM', function() {
+
+      let inputSelectBox;
+
+      beforeEach(inject(function(propertiesPanel) {
+        inputSelectBox = getInputParameterSelect(propertiesPanel._container);
+      }));
+
+
+      it('should execute', function() {
+
+        // then
+        expect(inputSelectBox.options.length).to.equal(1);
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(inputSelectBox.options.length).to.equal(0);
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(inputSelectBox.options.length).to.equal(1);
+      }));
+
+    });
+
+  });
+
+
+  describe('add output parameter', function() {
+
+    let bo;
+
+    beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+      // given
+      const container = propertiesPanel._container;
+
+      const shape = elementRegistry.get('ServiceTask_empty');
+      selection.select(shape);
+
+      bo = getBusinessObject(shape);
+
+      // when
+      clickAddOutputParameterButton(container);
+
+    }));
+
+
+    describe('on the business object', function() {
+
+      it('should execute', function() {
+
+        // then
+        expect(getOutputParameters(bo).length).to.equal(1);
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getOutputParameters(bo).length).to.equal(0);
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getOutputParameters(bo).length).to.equal(1);
+      }));
+
+    });
+
+
+    describe('in the DOM', function() {
+
+      let outputSelectBox;
+
+      beforeEach(inject(function(propertiesPanel) {
+        outputSelectBox = getOutputParameterSelect(propertiesPanel._container);
+      }));
+
+
+      it('should execute', function() {
+
+        // then
+        expect(outputSelectBox.options.length).to.equal(1);
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(outputSelectBox.options.length).to.equal(0);
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(outputSelectBox.options.length).to.equal(1);
+      }));
+
+    });
+
+  });
+
+
+  describe('select input parameter', function() {
+
+    let container;
+
+    beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+      // given
+      container = propertiesPanel._container;
+
+      const shape = elementRegistry.get('ServiceTask_1');
+      selection.select(shape);
+    }));
+
+    it('should nothing be selected', function() {
+
+      // then
+      expect(getInputParameterSelect(container).selectedIndex).to.equal(-1);
+    });
+
+
+    it('should select input parameter', function() {
+
+      // when
+      selectInputParameter(2, container);
+
+      // then
+      expect(getInputParameterSelect(container).selectedIndex).to.equal(2);
+      expect(getParameterSourceInput(container).value).to.equal('inputSourceValue3');
+    });
+
+
+    it('should deselect input parameter', function() {
+
+      // when
+      selectOutputParameter(2, container);
+
+      // then
+      expect(getInputParameterSelect(container).selectedIndex).to.equal(-1);
+    });
+
+  });
+
+
+  describe('select output parameter', function() {
+
+    let container;
+
+    beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+      // given
+      container = propertiesPanel._container;
+
+      const shape = elementRegistry.get('ServiceTask_1');
+      selection.select(shape);
+    }));
+
+    it('should nothing be selected', function() {
+
+      // then
+      expect(getOutputParameterSelect(container).selectedIndex).to.equal(-1);
+    });
+
+
+    it('should select output parameter', function() {
+
+      // when
+      selectOutputParameter(2, container);
+
+      // then
+      expect(getOutputParameterSelect(container).selectedIndex).to.equal(2);
+      expect(getParameterSourceInput(container).value).to.equal('outputSourceValue3');
+    });
+
+
+    it('should deselect output parameter', function() {
+
+      // when
+      selectInputParameter(2, container);
+
+      // then
+      expect(getOutputParameterSelect(container).selectedIndex).to.equal(-1);
+    });
+
+  });
+
+
+  describe('delete input parameter', function() {
+
+    let bo;
+
+    beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+      // given
+      const container = propertiesPanel._container;
+
+      const shape = elementRegistry.get('ServiceTask_1');
+      selection.select(shape);
+
+      bo = getBusinessObject(shape);
+
+      selectInputParameter(3, container);
+
+      // when
+      clickRemoveInputParameterButton(container);
+
+    }));
+
+
+    describe('on the business object', function() {
+
+      it('should execute', function() {
+
+        // then
+        expect(getInputParameters(bo).length).to.equal(3);
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getInputParameters(bo).length).to.equal(4);
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getInputParameters(bo).length).to.equal(3);
+      }));
+
+    });
+
+
+    describe('in the DOM', function() {
+
+      let inputSelectBox;
+
+      beforeEach(inject(function(propertiesPanel) {
+        inputSelectBox = getInputParameterSelect(propertiesPanel._container);
+      }));
+
+
+      it('should execute', function() {
+
+        // then
+        expect(inputSelectBox.options.length).to.equal(3);
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(inputSelectBox.options.length).to.equal(4);
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(inputSelectBox.options.length).to.equal(3);
+      }));
+
+    });
+
+  });
+
+
+  describe('delete output parameter', function() {
+
+    let bo;
+
+    beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+      // given
+      const container = propertiesPanel._container;
+
+      const shape = elementRegistry.get('ServiceTask_1');
+      selection.select(shape);
+
+      bo = getBusinessObject(shape);
+
+      selectOutputParameter(3, container);
+
+      // when
+      clickRemoveOutputParameterButton(container);
+
+    }));
+
+
+    describe('on the business object', function() {
+
+      it('should execute', function() {
+
+        // then
+        expect(getOutputParameters(bo).length).to.equal(3);
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getOutputParameters(bo).length).to.equal(4);
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getOutputParameters(bo).length).to.equal(3);
+      }));
+
+    });
+
+
+    describe('in the DOM', function() {
+
+      let outputSelectBox;
+
+      beforeEach(inject(function(propertiesPanel) {
+        outputSelectBox = getOutputParameterSelect(propertiesPanel._container);
+      }));
+
+
+      it('should execute', function() {
+
+        // then
+        expect(outputSelectBox.options.length).to.equal(3);
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(outputSelectBox.options.length).to.equal(4);
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(outputSelectBox.options.length).to.equal(3);
+      }));
+
+    });
+
+  });
+
+
+  describe('change parameter source', function() {
+
+    let parameterSourceInput,
+        parameter;
+
+    beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+      // given
+      const container = propertiesPanel._container;
+
+      const shape = elementRegistry.get('ServiceTask_1');
+      selection.select(shape);
+
+      // select first parameter
+      selectInputParameter(0, container);
+
+      parameterSourceInput = getParameterSourceInput(container);
+      parameter = getInputParameters(getBusinessObject(shape))[0];
+
+      // when
+      triggerValue(parameterSourceInput, 'foo', 'change');
+    }));
+
+
+    describe('in the DOM', function() {
+
+      it('should execute', function() {
+
+        // then
+        expect(parameterSourceInput.value).to.equal('foo');
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(parameterSourceInput.value).to.equal('inputSourceValue1');
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(parameterSourceInput.value).to.equal('foo');
+      }));
+
+
+      it('should validate', function() {
+
+        // when
+        triggerValue(parameterSourceInput, '', 'change');
+
+        // then
+        expect(domClasses(parameterSourceInput).has('invalid')).to.be.true;
+      });
+
+
+      it('should validate with spaces', function() {
+
+        // when
+        triggerValue(parameterSourceInput, 'foo bar', 'change');
+
+        // then
+        expect(domClasses(parameterSourceInput).has('invalid')).to.be.true;
+      });
+
+    });
+
+
+    describe('on the business object', function() {
+
+      it('should execute', function() {
+
+        // then
+        expect(parameter.source).to.equal('foo');
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(parameter.source).to.equal('inputSourceValue1');
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(parameter.source).to.equal('foo');
+      }));
+
+    });
+
+  });
+
+
+  describe('change parameter target', function() {
+
+    let parameterTargetInput,
+        parameter;
+
+    beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+      // given
+      const container = propertiesPanel._container;
+
+      const shape = elementRegistry.get('ServiceTask_1');
+      selection.select(shape);
+
+      // select first parameter
+      selectInputParameter(0, container);
+
+      parameterTargetInput = getParameterTargetInput(container);
+      parameter = getInputParameters(getBusinessObject(shape))[0];
+
+      // when
+      triggerValue(parameterTargetInput, 'foo', 'change');
+    }));
+
+
+    describe('in the DOM', function() {
+
+      it('should execute', function() {
+
+        // then
+        expect(parameterTargetInput.value).to.equal('foo');
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(parameterTargetInput.value).to.equal('inputTargetValue1');
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(parameterTargetInput.value).to.equal('foo');
+      }));
+
+
+      it('should validate', function() {
+
+        // when
+        triggerValue(parameterTargetInput, '', 'change');
+
+        // then
+        expect(domClasses(parameterTargetInput).has('invalid')).to.be.true;
+      });
+
+
+      it('should validate with spaces', function() {
+
+        // when
+        triggerValue(parameterTargetInput, 'foo bar', 'change');
+
+        // then
+        expect(domClasses(parameterTargetInput).has('invalid')).to.be.true;
+      });
+
+    });
+
+
+    describe('on the business object', function() {
+
+      it('should execute', function() {
+
+        // then
+        expect(parameter.target).to.equal('foo');
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(parameter.target).to.equal('inputTargetValue1');
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(parameter.target).to.equal('foo');
+      }));
+
+    });
+
+  });
+
+});
+
+
+// helper /////////
+
+const getInputParameters = (bo) => {
+  return getParameters(bo, 'inputParameters');
+};
+
+const getElements = (bo, type, prop) => {
+  const elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  return !prop ? elems : (elems[0] || {})[prop] || [];
+};
+
+const getOutputParameters = (bo) => {
+  return getParameters(bo, 'outputParameters');
+};
+
+const getParameters = (bo, prop) => {
+  return getElements(bo, 'zeebe:IoMapping', prop);
+};
+
+const getInputParameterSelect = (container) => {
+  return getSelect('inputs', container);
+};
+
+const getAddInputParameterButton = (container) => {
+  return getAddButton('inputs', container);
+};
+
+const clickAddInputParameterButton = (container) => {
+  const addButton = getAddInputParameterButton(container);
+  triggerEvent(addButton, 'click');
+};
+
+const getRemoveInputParameterButton = (container) => {
+  return getRemoveButton('inputs', container);
+};
+
+const clickRemoveInputParameterButton = (container) => {
+  const removeButton = getRemoveInputParameterButton(container);
+  triggerEvent(removeButton, 'click');
+};
+
+const selectInputParameter = (idx, container) => {
+  const selectBox = getInputParameterSelect(container);
+  selectBox.options[idx].selected = 'selected';
+  triggerEvent(selectBox, 'change');
+};
+
+const getOutputParameterSelect = (container) => {
+  return getSelect('outputs', container);
+};
+
+const getAddOutputParameterButton = (container) => {
+  return getAddButton('outputs', container);
+};
+
+const clickAddOutputParameterButton = (container) => {
+  const addButton = getAddOutputParameterButton(container);
+  triggerEvent(addButton, 'click');
+};
+
+const getRemoveOutputParameterButton = (container) => {
+  return getRemoveButton('outputs', container);
+};
+
+const clickRemoveOutputParameterButton = (container) => {
+  const removeButton = getRemoveOutputParameterButton(container);
+  triggerEvent(removeButton, 'click');
+};
+
+const selectOutputParameter = (idx, container) => {
+  const selectBox = getOutputParameterSelect(container);
+  selectBox.options[idx].selected = 'selected';
+  triggerEvent(selectBox, 'change');
+};
+
+const getInputOutputTab = (container) => {
+  return domQuery('div[data-tab="input-output"]', container);
+};
+
+const getParameterSourceInput = (container) => {
+  return domQuery('input[id="camunda-parameterSource"]', getInputOutputTab(container));
+};
+
+const getParameterTargetInput = (container) => {
+  return domQuery('input[id="camunda-parameterTarget"]', getInputOutputTab(container));
+};
+
+const getSelect = (suffix, container) => {
+  return domQuery('select[id="cam-extensionElements-' + suffix + '"]', getInputOutputTab(container));
+};
+
+const getAddButton = (suffix, container) => {
+  return domQuery('button[id="cam-extensionElements-create-' + suffix + '"]', getInputOutputTab(container));
+};
+
+const getRemoveButton = (suffix, container) => {
+  return domQuery('button[id="cam-extensionElements-remove-' + suffix + '"]', getInputOutputTab(container));
+};

--- a/client/src/app/tabs/bpmn/custom/properties-provider/helper/InputOutputHelper.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/helper/InputOutputHelper.js
@@ -96,7 +96,7 @@ export function getOutputParameter(element, idx) {
    * @return {boolean} a boolean value
    */
 export function isInputOutputSupported(element) {
-  return areOutputParametersSupported(element) || areOutputParametersSupported(element);
+  return areOutputParametersSupported(element) || areInputParametersSupported(element);
 }
 
 /**
@@ -120,8 +120,9 @@ export function areInputParametersSupported(element) {
    */
 export function areOutputParametersSupported(element) {
   const bo = getBusinessObject(element);
-  if (is(bo, 'bpmn:ServiceTask') || is(bo, 'bpmn:SubProcess') || is(bo, 'bpmn:ReceiveTask'))
+  if (is(bo, 'bpmn:ServiceTask') || is(bo, 'bpmn:SubProcess') || is(bo, 'bpmn:ReceiveTask')) {
     return true;
+  }
 
   const messageEventDefinition = eventDefinitionHelper.getMessageEventDefinition(element);
   return messageEventDefinition;

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/InputOutput.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/InputOutput.js
@@ -47,11 +47,11 @@ function ensureInputOutputSupported(element) {
   return isInputOutputSupported(element);
 }
 
-function ensureOutparameterSupported(element) {
+function ensureOutParameterSupported(element) {
   return areOutputParametersSupported(element);
 }
 
-function ensureInputparameterSupported(element) {
+function ensureInputParameterSupported(element) {
   return areInputParametersSupported(element);
 }
 
@@ -141,7 +141,7 @@ export default function(element, bpmnFactory, options = {}) {
 
 
   // input parameters ///////////////////////////////////////////////////////////////
-  if (ensureInputparameterSupported(element)) {
+  if (ensureInputParameterSupported(element)) {
     inputEntry = extensionElementsEntry(element, bpmnFactory, {
       id: `${idPrefix}inputs`,
       label: 'Input Parameters',
@@ -169,7 +169,7 @@ export default function(element, bpmnFactory, options = {}) {
 
   // output parameters ///////////////////////////////////////////////////////
 
-  if (ensureOutparameterSupported(element)) {
+  if (ensureOutParameterSupported(element)) {
     outputEntry = extensionElementsEntry(element, bpmnFactory, {
       id: `${idPrefix}outputs`,
       label: 'Output Parameters',

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/TimerDurationDefinition.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/TimerDurationDefinition.js
@@ -28,54 +28,52 @@ function createFormalExpression(parent, body = undefined, bpmnFactory) {
   return elementHelper.createElement('bpmn:FormalExpression', { body: body }, parent, bpmnFactory);
 }
 
-export default class TimerDurationDefinition {
+export default function(group, bpmnFactory, timerEventDefinition) {
+  group.entries.push(entryFactory.textField({
+    id: 'timer-event-duration',
+    label: 'Timer Duration',
+    modelProperty: 'timerDefinition',
 
-  constructor(group, element, bpmnFactory, timerEventDefinition) {
-    group.entries.push(entryFactory.textField({
-      id: 'timer-event-duration',
-      label: 'Timer Duration',
-      modelProperty: 'timerDefinition',
+    get: function(element, node) {
+      const type = 'timeDuration';
+      const definition = type && timerEventDefinition.get(type);
+      const value = definition && definition.get('body');
+      return {
+        timerDefinition: value
+      };
+    },
 
-      get: function(element, node) {
-        const type = 'timeDuration';
-        const definition = type && timerEventDefinition.get(type);
-        const value = definition && definition.get('body');
-        return {
-          timerDefinition: value
-        };
-      },
+    set: function(element, values) {
+      const type = 'timeDuration';
+      let definition = type && timerEventDefinition.get(type);
+      const commands = [];
 
-      set: function(element, values) {
-        const type = 'timeDuration';
-        let definition = type && timerEventDefinition.get(type);
-        const commands = [];
+      if (!definition) {
+        definition = createFormalExpression(timerEventDefinition, {}, bpmnFactory);
+        commands.push(cmdHelper.updateBusinessObject(element, timerEventDefinition, { 'timeDuration': definition }));
+      }
 
-        if (!definition) {
-          definition = createFormalExpression(timerEventDefinition, {}, bpmnFactory);
-          commands.push(cmdHelper.updateBusinessObject(element, timerEventDefinition, { 'timeDuration': definition }));
-        }
+      if (definition) {
+        commands.push(cmdHelper.updateBusinessObject(element, definition, {
+          body: values.timerDefinition || undefined
+        }));
+        return commands;
+      }
+    },
 
-        if (definition) {
-          commands.push(cmdHelper.updateBusinessObject(element, definition, {
-            body: values.timerDefinition || undefined
-          }));
-          return commands;
-        }
-      },
-
-      validate: function(element) {
-        const type = 'timeDuration';
-        const definition = type && timerEventDefinition.get(type);
-        if (definition) {
-          const value = definition.get('body');
-          if (!value) {
-            return {
-              timerDefinition: 'Must provide a value'
-            };
-          }
+    validate: function(element) {
+      const type = 'timeDuration';
+      const definition = type && timerEventDefinition.get(type);
+      if (definition) {
+        const value = definition.get('body');
+        if (!value) {
+          return {
+            timerDefinition: 'Must provide a value'
+          };
         }
       }
-    }));
-  }
+    }
+  }));
+
 
 }


### PR DESCRIPTION
To make the Zeebe custom implementations a little more stable for the next release (#97), I took a run through the codebase and ship a couple of improvements.

* Create a complete test suite for `zeebe:IoMapping` properties
* Refactor the `ZeebeCreateBoundaryEventBehavior`
* Add test coverage for the `CustomPaletteProvider`
* Refactor the overall `TimerEventProps` implementation

---

Related to #87 