### PR TITLE
fix(client/context-pad-provider): set source on drag start

### DIFF
--- a/client/src/app/tabs/bpmn/custom/CustomContextPadProvider.js
+++ b/client/src/app/tabs/bpmn/custom/CustomContextPadProvider.js
@@ -70,7 +70,9 @@ export default class CustomContextPadProvider extends ContextPadProvider {
       function appendStart(event, element) {
 
         const shape = self._elementFactory.createShape(assign({ type: type }, options));
-        self._create.start(event, shape, element);
+        self._create.start(event, shape, {
+          source: element
+        });
       }
 
 

--- a/client/src/app/tabs/bpmn/custom/__tests__/CustomContextPadProviderSpec.js
+++ b/client/src/app/tabs/bpmn/custom/__tests__/CustomContextPadProviderSpec.js
@@ -279,6 +279,31 @@ describe('customs - context-pad', function() {
       // then
       expect(dragging.context()).to.exist;
     }));
+
+
+    it('should set source on drag start', inject(function(elementRegistry, contextPad, dragging) {
+
+      // given
+      const element = elementRegistry.get('ServiceTask_1');
+
+      contextPad.open(element);
+
+      // mock event
+      const event = padEvent('append.append-service-task');
+
+      // when
+      contextPad.trigger('click', event);
+
+      const draggingContext = dragging.context();
+
+      const {
+        source
+      } = draggingContext.data.context;
+
+      // then
+      expect(source).to.eql(element);
+    }));
+
   });
 
 });


### PR DESCRIPTION
Necessary due to [breaking changes in `diagram-js@5.0.0`](https://github.com/bpmn-io/diagram-js/blob/develop/CHANGELOG.md#500),

Closes #110 

![Kapture 2019-09-24 at 11 51 51](https://user-images.githubusercontent.com/9433996/65501706-bf3cd480-dec1-11e9-9221-8b8e21bc6f5f.gif)

