### PR TITLE
Development Logo

### DIFF
--- a/resources/plugins/test/assets/logo-template.svg
+++ b/resources/plugins/test/assets/logo-template.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="52" height="52">
-  <rect x="0" y="0" rx="4" ry="4" width="52" height="52" fill="#52B415" />
-  <text x="4" y="48" fill="#FFF" style="font-family: Arial, sans-serif; font-size: 10px; font-weight: bold;">{version}</text>
-</svg>

--- a/resources/plugins/test/assets/logo.svg
+++ b/resources/plugins/test/assets/logo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="52" height="52">
   <rect x="0" y="0" rx="4" ry="4" width="52" height="52" fill="#52B415" />
-  <text x="4" y="48" fill="#FFF" style="font-family: Arial, sans-serif; font-size: 10px; font-weight: bold;">0.7.0-dev</text>
+  <text x="4" y="48" fill="#FFF" style="font-family: Arial, sans-serif; font-size: 10px; font-weight: bold;">dev</text>
 </svg>

--- a/resources/plugins/test/assets/logo.svg
+++ b/resources/plugins/test/assets/logo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="52" height="52">
-  <rect x="0" y="0" rx="4" ry="4" width="52" height="52" fill="#52B415" />
+  <rect x="0" y="0" rx="4" ry="4" width="52" height="52" fill="#4D90FF" />
   <text x="4" y="48" fill="#FFF" style="font-family: Arial, sans-serif; font-size: 10px; font-weight: bold;">dev</text>
 </svg>

--- a/resources/plugins/test/menu.js
+++ b/resources/plugins/test/menu.js
@@ -8,16 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-const fs = require('fs');
-
-const path = require('path');
-
 module.exports = function(electronApp, menuState) {
-  var file = fs.readFileSync(path.resolve(__dirname, './assets/logo-template.svg'), 'utf8');
-
-  file = file.replace('{version}', electronApp.version);
-
-  fs.writeFileSync(path.resolve(__dirname, './assets/logo.svg'), file, 'utf8');
 
   return [
     {


### PR DESCRIPTION
This sets the color of the development logo inside the Editor, for a better distinction to the Camunda Modeler, at least in dev mode. Discussed in [our last Weekly](distinguishable).

It also removes the node hacks from the test plugin, as we already did in the Camunda Modeler, cf. https://github.com/camunda/camunda-modeler/commit/02e909df5ae467bd3f47874ffba1e5057a1d34b9

![image](https://user-images.githubusercontent.com/9433996/66479609-2dc28a80-ea9d-11e9-9161-5525639765ba.png)
