### PR TITLE
Align Replace Menu

### DIFF
--- a/client/src/app/tabs/bpmn/custom/CustomReplaceMenuProvider.js
+++ b/client/src/app/tabs/bpmn/custom/CustomReplaceMenuProvider.js
@@ -11,6 +11,11 @@
 import ReplaceMenuProvider from 'bpmn-js/lib/features/popup-menu/ReplaceMenuProvider';
 
 import {
+  bind,
+  find
+} from 'min-dash';
+
+import {
   isEventSubProcess
 } from 'bpmn-js/lib/util/DiUtil';
 
@@ -19,7 +24,7 @@ import {
 } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
 
 import {
-  AVAILABLE_REPLACE_ELEMENTS as availableElements,
+  AVAILABLE_REPLACE_ELEMENTS as availableReplaceElements,
   AVAILABLE_LOOP_ENTRIES as availableLoopEntries
 } from './modeler-options/Options';
 
@@ -27,12 +32,8 @@ export default class CustomReplaceMenuProvider extends ReplaceMenuProvider {
 
   constructor(popupMenu, modeling, moddle, bpmnReplace, rules, translate) {
     super(popupMenu, modeling, moddle, bpmnReplace, rules, translate);
-  }
 
-  // For future element support!!
-  _createEntries(element, replaceOptions) {
-    let options = ReplaceMenuProvider.prototype._createEntries.call(this, element, replaceOptions);
-    return options.filter(option => availableElements.indexOf(option.id) != -1);
+    this.defaultEntries = bind(super.getEntries, this);
   }
 
   getHeaderEntries(element) {
@@ -47,11 +48,21 @@ export default class CustomReplaceMenuProvider extends ReplaceMenuProvider {
       const loopEntries = this._getLoopEntries(element);
 
       headerEntries = loopEntries.filter(
-        entry => availableLoopEntries.indexOf(entry.id) != -1
+        entry => availableLoopEntries.indexOf(entry.id) !== -1
       );
     }
 
     return headerEntries;
+  }
+
+  getEntries(element) {
+    const entries = this.defaultEntries(element);
+
+    const filteredEntries = entries.filter(entry => {
+      return find(availableReplaceElements, a => a === entry.id);
+    });
+
+    return filteredEntries;
   }
 }
 

--- a/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
+++ b/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
@@ -48,14 +48,15 @@ describe('customs - replaceMenu', function() {
     openPopup(startEvent);
 
     const endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
+          intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throwing'),
           messageStartEntry = queryEntry(popupMenu, 'replace-with-message-start'),
           timerStartEntry = queryEntry(popupMenu, 'replace-with-timer-start');
 
     // then
     expect(endEventEntry).to.exist;
+    expect(intermediateEventEntry).to.exist;
     expect(messageStartEntry).to.exist;
     expect(timerStartEntry).to.exist;
-
   }));
 
 
@@ -67,11 +68,12 @@ describe('customs - replaceMenu', function() {
 
     openPopup(endEvent);
 
-    const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start');
+    const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
+          intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw');
 
     // then
     expect(startEventEntry).to.exist;
-
+    expect(intermediateEventEntry).to.exist;
   }));
 
 
@@ -85,14 +87,14 @@ describe('customs - replaceMenu', function() {
 
     const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
           endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
+          intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
           messageEventEntry = queryEntry(popupMenu, 'replace-with-message-intermediate-catch');
-
 
     // then
     expect(startEventEntry).to.exist;
     expect(endEventEntry).to.exist;
+    expect(intermediateEventEntry).to.exist;
     expect(messageEventEntry).to.exist;
-
   }));
 
 
@@ -106,13 +108,39 @@ describe('customs - replaceMenu', function() {
 
     const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
           endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
+          intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
           timerEventEntry = queryEntry(popupMenu, 'replace-with-timer-intermediate-catch');
 
     // then
     expect(startEventEntry).to.exist;
     expect(endEventEntry).to.exist;
+    expect(intermediateEventEntry).to.exist;
     expect(timerEventEntry).to.exist;
+  }));
 
+
+  it('should contain options for BoundaryEvent', inject(function(
+      popupMenu, elementRegistry) {
+
+    // given
+    const endEvent = elementRegistry.get('BoundaryEvent_1');
+
+    openPopup(endEvent);
+
+    const messageBoundaryEntry = queryEntry(popupMenu, 'replace-with-message-boundary'),
+          timerBoundaryEntry = queryEntry(popupMenu, 'replace-with-timer-boundary'),
+          errorBoundaryEntry = queryEntry(popupMenu, 'replace-with-error-boundary'),
+          nonInterruptingMessageBoundaryEntry =
+          queryEntry(popupMenu, 'replace-with-non-interrupting-message-boundary'),
+          nonInterruptingTimerBoundaryEntry =
+          queryEntry(popupMenu, 'replace-with-non-interrupting-timer-boundary');
+
+    // then
+    expect(messageBoundaryEntry).to.exist;
+    expect(timerBoundaryEntry).to.exist;
+    expect(errorBoundaryEntry).to.exist;
+    expect(nonInterruptingMessageBoundaryEntry).to.exist;
+    expect(nonInterruptingTimerBoundaryEntry).to.exist;
   }));
 
 
@@ -124,19 +152,20 @@ describe('customs - replaceMenu', function() {
 
     openPopup(messageTask);
 
-    const serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
+    const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
+          serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
           collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
           expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
           sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
           parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
     // then
+    expect(taskEntry).to.exist;
     expect(serviceTaskEntry).to.exist;
     expect(collapsedSubProcessEntry).to.exist;
     expect(expandedSubProcessEntry).to.exist;
     expect(sequentialMultiInstanceEntry).to.exist;
     expect(parallelMultiInstanceEntry).to.exist;
-
   }));
 
 
@@ -148,19 +177,20 @@ describe('customs - replaceMenu', function() {
 
     openPopup(serviceTask);
 
-    const receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
+    const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
+          receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
           collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
           expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
           sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
           parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
     // then
+    expect(taskEntry).to.exist;
+    expect(receiveTaskEntry).to.exist;
     expect(collapsedSubProcessEntry).to.exist;
     expect(expandedSubProcessEntry).to.exist;
-    expect(receiveTaskEntry).to.exist;
     expect(sequentialMultiInstanceEntry).to.exist;
     expect(parallelMultiInstanceEntry).to.exist;
-
   }));
 
 
@@ -178,7 +208,6 @@ describe('customs - replaceMenu', function() {
     // then
     expect(exclusiveGatewayEntry).to.exist;
     expect(parallelGatewayEntry).to.exist;
-
   }));
 
 
@@ -196,11 +225,10 @@ describe('customs - replaceMenu', function() {
     // then
     expect(exclusiveGatewayEntry).to.exist;
     expect(eventBasedGatewayEntry).to.exist;
-
   }));
 
 
-  it('should contain options for Exclusive', inject(function(
+  it('should contain options for ExclusiveGateway', inject(function(
       popupMenu, elementRegistry) {
 
     // given
@@ -214,7 +242,6 @@ describe('customs - replaceMenu', function() {
     // then
     expect(parallelGatewayEntry).to.exist;
     expect(eventBasedGatewayEntry).to.exist;
-
   }));
 
 
@@ -226,19 +253,20 @@ describe('customs - replaceMenu', function() {
 
     openPopup(subProcess);
 
-    const receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
+    const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
+          receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
           serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
           expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
           sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
           parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
     // then
+    expect(taskEntry).to.exist;
     expect(serviceTaskEntry).to.exist;
     expect(expandedSubProcessEntry).to.exist;
     expect(receiveTaskEntry).to.exist;
     expect(sequentialMultiInstanceEntry).to.exist;
     expect(parallelMultiInstanceEntry).to.exist;
-
   }));
 
 
@@ -260,28 +288,52 @@ describe('customs - replaceMenu', function() {
     expect(eventSubProcessEntry).to.exist;
     expect(sequentialMultiInstanceEntry).to.exist;
     expect(parallelMultiInstanceEntry).to.exist;
-
   }));
 
 
-  it('should contain options for Event SubProcess', inject(function(
-      popupMenu, elementRegistry) {
+  describe('event sub process', function() {
 
-    // given
-    const eventSubProcess = elementRegistry.get('EventSubProcess1');
+    it('should contain options for EventSubProcess', inject(function(
+        popupMenu, elementRegistry) {
 
-    openPopup(eventSubProcess);
+      // given
+      const eventSubProcess = elementRegistry.get('EventSubProcess1');
 
-    const subProcessEntry = queryEntry(popupMenu, 'replace-with-subprocess'),
-          sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
-          parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
+      openPopup(eventSubProcess);
 
-    // then
-    expect(subProcessEntry).to.exist;
-    expect(sequentialMultiInstanceEntry).to.not.exist;
-    expect(parallelMultiInstanceEntry).to.not.exist;
+      const subProcessEntry = queryEntry(popupMenu, 'replace-with-subprocess'),
+            sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
+            parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
-  }));
+      // then
+      expect(subProcessEntry).to.exist;
+      expect(sequentialMultiInstanceEntry).to.not.exist;
+      expect(parallelMultiInstanceEntry).to.not.exist;
+    }));
+
+
+    it('should contain options for StartEvent in EventSubProcess', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_2');
+
+      openPopup(startEvent);
+
+      const timerStartEntry = queryEntry(popupMenu, 'replace-with-timer-start'),
+            messageStartEntry = queryEntry(popupMenu, 'replace-with-message-start'),
+            errorStartEntry = queryEntry(popupMenu, 'replace-with-error-start'),
+            messageNonInterruptingEntry = queryEntry(popupMenu, 'replace-with-non-interrupting-message-start'),
+            timerNonInterruptingEntry = queryEntry(popupMenu, 'replace-with-non-interrupting-timer-start');
+
+      // then
+      expect(timerStartEntry).to.exist;
+      expect(messageStartEntry).to.exist;
+      expect(errorStartEntry).to.exist;
+      expect(messageNonInterruptingEntry).to.exist;
+      expect(timerNonInterruptingEntry).to.exist;
+    }));
+  });
 
 });
 

--- a/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
+++ b/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
@@ -39,256 +39,293 @@ describe('customs - replaceMenu', function() {
 
   beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
 
-  it('should contain options for StartEvent', inject(function(
-      popupMenu, elementRegistry) {
+  describe('events', function() {
 
-    // given
-    const startEvent = elementRegistry.get('StartEvent_1');
+    it('should contain options for StartEvent', inject(function(
+        popupMenu, elementRegistry) {
 
-    openPopup(startEvent);
+      // given
+      const startEvent = elementRegistry.get('StartEvent_1');
 
-    const endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
-          intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throwing'),
-          messageStartEntry = queryEntry(popupMenu, 'replace-with-message-start'),
-          timerStartEntry = queryEntry(popupMenu, 'replace-with-timer-start');
+      openPopup(startEvent);
 
-    // then
-    expect(endEventEntry).to.exist;
-    expect(intermediateEventEntry).to.exist;
-    expect(messageStartEntry).to.exist;
-    expect(timerStartEntry).to.exist;
-  }));
+      const endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
+            intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throwing'),
+            messageStartEntry = queryEntry(popupMenu, 'replace-with-message-start'),
+            timerStartEntry = queryEntry(popupMenu, 'replace-with-timer-start');
 
-
-  it('should contain options for EndEvent', inject(function(
-      popupMenu, elementRegistry) {
-
-    // given
-    const endEvent = elementRegistry.get('EndEvent_1');
-
-    openPopup(endEvent);
-
-    const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
-          intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw');
-
-    // then
-    expect(startEventEntry).to.exist;
-    expect(intermediateEventEntry).to.exist;
-  }));
+      // then
+      expect(endEventEntry).to.exist;
+      expect(intermediateEventEntry).to.exist;
+      expect(messageStartEntry).to.exist;
+      expect(timerStartEntry).to.exist;
+    }));
 
 
-  it('should contain options for TimerEvent', inject(function(
-      popupMenu, elementRegistry) {
+    it('should contain options for EndEvent', inject(function(
+        popupMenu, elementRegistry) {
 
-    // given
-    const timerEvent = elementRegistry.get('TimerEvent_1');
+      // given
+      const endEvent = elementRegistry.get('EndEvent_1');
 
-    openPopup(timerEvent);
+      openPopup(endEvent);
 
-    const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
-          endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
-          intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
-          messageEventEntry = queryEntry(popupMenu, 'replace-with-message-intermediate-catch');
+      const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
+            intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw');
 
-    // then
-    expect(startEventEntry).to.exist;
-    expect(endEventEntry).to.exist;
-    expect(intermediateEventEntry).to.exist;
-    expect(messageEventEntry).to.exist;
-  }));
+      // then
+      expect(startEventEntry).to.exist;
+      expect(intermediateEventEntry).to.exist;
+    }));
 
 
-  it('should contain options for MessageEvent', inject(function(
-      popupMenu, elementRegistry) {
+    it('should contain options for TimerEvent', inject(function(
+        popupMenu, elementRegistry) {
 
-    // given
-    const timerEvent = elementRegistry.get('MessageEvent_1');
+      // given
+      const timerEvent = elementRegistry.get('TimerEvent_1');
 
-    openPopup(timerEvent);
+      openPopup(timerEvent);
 
-    const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
-          endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
-          intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
-          timerEventEntry = queryEntry(popupMenu, 'replace-with-timer-intermediate-catch');
+      const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
+            endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
+            intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
+            messageEventEntry = queryEntry(popupMenu, 'replace-with-message-intermediate-catch');
 
-    // then
-    expect(startEventEntry).to.exist;
-    expect(endEventEntry).to.exist;
-    expect(intermediateEventEntry).to.exist;
-    expect(timerEventEntry).to.exist;
-  }));
+      // then
+      expect(startEventEntry).to.exist;
+      expect(endEventEntry).to.exist;
+      expect(intermediateEventEntry).to.exist;
+      expect(messageEventEntry).to.exist;
+    }));
 
 
-  it('should contain options for BoundaryEvent', inject(function(
-      popupMenu, elementRegistry) {
+    it('should contain options for MessageEvent', inject(function(
+        popupMenu, elementRegistry) {
 
-    // given
-    const endEvent = elementRegistry.get('BoundaryEvent_1');
+      // given
+      const timerEvent = elementRegistry.get('MessageEvent_1');
 
-    openPopup(endEvent);
+      openPopup(timerEvent);
 
-    const messageBoundaryEntry = queryEntry(popupMenu, 'replace-with-message-boundary'),
-          timerBoundaryEntry = queryEntry(popupMenu, 'replace-with-timer-boundary'),
-          errorBoundaryEntry = queryEntry(popupMenu, 'replace-with-error-boundary'),
-          nonInterruptingMessageBoundaryEntry =
+      const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
+            endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
+            intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
+            timerEventEntry = queryEntry(popupMenu, 'replace-with-timer-intermediate-catch');
+
+      // then
+      expect(startEventEntry).to.exist;
+      expect(endEventEntry).to.exist;
+      expect(intermediateEventEntry).to.exist;
+      expect(timerEventEntry).to.exist;
+    }));
+
+
+    it('should contain options for BoundaryEvent', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const endEvent = elementRegistry.get('BoundaryEvent_1');
+
+      openPopup(endEvent);
+
+      const messageBoundaryEntry = queryEntry(popupMenu, 'replace-with-message-boundary'),
+            timerBoundaryEntry = queryEntry(popupMenu, 'replace-with-timer-boundary'),
+            errorBoundaryEntry = queryEntry(popupMenu, 'replace-with-error-boundary'),
+            nonInterruptingMessageBoundaryEntry =
           queryEntry(popupMenu, 'replace-with-non-interrupting-message-boundary'),
-          nonInterruptingTimerBoundaryEntry =
+            nonInterruptingTimerBoundaryEntry =
           queryEntry(popupMenu, 'replace-with-non-interrupting-timer-boundary');
 
-    // then
-    expect(messageBoundaryEntry).to.exist;
-    expect(timerBoundaryEntry).to.exist;
-    expect(errorBoundaryEntry).to.exist;
-    expect(nonInterruptingMessageBoundaryEntry).to.exist;
-    expect(nonInterruptingTimerBoundaryEntry).to.exist;
-  }));
+      // then
+      expect(messageBoundaryEntry).to.exist;
+      expect(timerBoundaryEntry).to.exist;
+      expect(errorBoundaryEntry).to.exist;
+      expect(nonInterruptingMessageBoundaryEntry).to.exist;
+      expect(nonInterruptingTimerBoundaryEntry).to.exist;
+    }));
+
+  });
 
 
-  it('should contain options for MessageTask', inject(function(
-      popupMenu, elementRegistry) {
+  describe('activities', function() {
 
-    // given
-    const messageTask = elementRegistry.get('MessageTask_1');
+    it('should contain options for Task', inject(function(
+        popupMenu, elementRegistry) {
 
-    openPopup(messageTask);
+      // given
+      const task = elementRegistry.get('Task_1');
 
-    const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
-          serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
-          collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
-          expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
-          sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
-          parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
+      openPopup(task);
 
-    // then
-    expect(taskEntry).to.exist;
-    expect(serviceTaskEntry).to.exist;
-    expect(collapsedSubProcessEntry).to.exist;
-    expect(expandedSubProcessEntry).to.exist;
-    expect(sequentialMultiInstanceEntry).to.exist;
-    expect(parallelMultiInstanceEntry).to.exist;
-  }));
+      const messageTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
+            serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
+            collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
+            expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess');
+
+      // then
+      expect(messageTaskEntry).to.exist;
+      expect(serviceTaskEntry).to.exist;
+      expect(collapsedSubProcessEntry).to.exist;
+      expect(expandedSubProcessEntry).to.exist;
+    }));
 
 
-  it('should contain options for ServiceTask', inject(function(
-      popupMenu, elementRegistry) {
+    it('should contain options for MessageTask', inject(function(
+        popupMenu, elementRegistry) {
 
-    // given
-    const serviceTask = elementRegistry.get('ServiceTask_1');
+      // given
+      const messageTask = elementRegistry.get('MessageTask_1');
 
-    openPopup(serviceTask);
+      openPopup(messageTask);
 
-    const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
-          receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
-          collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
-          expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
-          sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
-          parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
+      const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
+            serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
+            collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
+            expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
+            sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
+            parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
-    // then
-    expect(taskEntry).to.exist;
-    expect(receiveTaskEntry).to.exist;
-    expect(collapsedSubProcessEntry).to.exist;
-    expect(expandedSubProcessEntry).to.exist;
-    expect(sequentialMultiInstanceEntry).to.exist;
-    expect(parallelMultiInstanceEntry).to.exist;
-  }));
-
-
-  it('should contain options for EventBasedGateway', inject(function(
-      popupMenu, elementRegistry) {
-
-    // given
-    const eventBasedGateway = elementRegistry.get('EventBasedGateway_1');
-
-    openPopup(eventBasedGateway);
-
-    const exclusiveGatewayEntry = queryEntry(popupMenu, 'replace-with-exclusive-gateway'),
-          parallelGatewayEntry = queryEntry(popupMenu, 'replace-with-parallel-gateway');
-
-    // then
-    expect(exclusiveGatewayEntry).to.exist;
-    expect(parallelGatewayEntry).to.exist;
-  }));
+      // then
+      expect(taskEntry).to.exist;
+      expect(serviceTaskEntry).to.exist;
+      expect(collapsedSubProcessEntry).to.exist;
+      expect(expandedSubProcessEntry).to.exist;
+      expect(sequentialMultiInstanceEntry).to.exist;
+      expect(parallelMultiInstanceEntry).to.exist;
+    }));
 
 
-  it('should contain options for ParallelGateway', inject(function(
-      popupMenu, elementRegistry) {
+    it('should contain options for ServiceTask', inject(function(
+        popupMenu, elementRegistry) {
 
-    // given
-    const parallelGateway = elementRegistry.get('ParallelGateway_1');
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
 
-    openPopup(parallelGateway);
+      openPopup(serviceTask);
 
-    const exclusiveGatewayEntry = queryEntry(popupMenu, 'replace-with-exclusive-gateway'),
-          eventBasedGatewayEntry = queryEntry(popupMenu, 'replace-with-event-based-gateway');
+      const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
+            receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
+            collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
+            expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
+            sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
+            parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
-    // then
-    expect(exclusiveGatewayEntry).to.exist;
-    expect(eventBasedGatewayEntry).to.exist;
-  }));
+      // then
+      expect(taskEntry).to.exist;
+      expect(receiveTaskEntry).to.exist;
+      expect(collapsedSubProcessEntry).to.exist;
+      expect(expandedSubProcessEntry).to.exist;
+      expect(sequentialMultiInstanceEntry).to.exist;
+      expect(parallelMultiInstanceEntry).to.exist;
+    }));
 
-
-  it('should contain options for ExclusiveGateway', inject(function(
-      popupMenu, elementRegistry) {
-
-    // given
-    const exclusiveGateway = elementRegistry.get('ExclusiveGateway_1');
-
-    openPopup(exclusiveGateway);
-
-    const parallelGatewayEntry = queryEntry(popupMenu, 'replace-with-parallel-gateway'),
-          eventBasedGatewayEntry = queryEntry(popupMenu, 'replace-with-event-based-gateway');
-
-    // then
-    expect(parallelGatewayEntry).to.exist;
-    expect(eventBasedGatewayEntry).to.exist;
-  }));
+  });
 
 
-  it('should contain options for (collapsed) SubProcess', inject(function(
-      popupMenu, elementRegistry) {
+  describe('gateways', function() {
 
-    // given
-    const subProcess = elementRegistry.get('SubProcess_1');
+    it('should contain options for EventBasedGateway', inject(function(
+        popupMenu, elementRegistry) {
 
-    openPopup(subProcess);
+      // given
+      const eventBasedGateway = elementRegistry.get('EventBasedGateway_1');
 
-    const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
-          receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
-          serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
-          expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
-          sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
-          parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
+      openPopup(eventBasedGateway);
 
-    // then
-    expect(taskEntry).to.exist;
-    expect(serviceTaskEntry).to.exist;
-    expect(expandedSubProcessEntry).to.exist;
-    expect(receiveTaskEntry).to.exist;
-    expect(sequentialMultiInstanceEntry).to.exist;
-    expect(parallelMultiInstanceEntry).to.exist;
-  }));
+      const exclusiveGatewayEntry = queryEntry(popupMenu, 'replace-with-exclusive-gateway'),
+            parallelGatewayEntry = queryEntry(popupMenu, 'replace-with-parallel-gateway');
+
+      // then
+      expect(exclusiveGatewayEntry).to.exist;
+      expect(parallelGatewayEntry).to.exist;
+    }));
 
 
-  it('should contain options for (expanded) SubProcess', inject(function(
-      popupMenu, elementRegistry) {
+    it('should contain options for ParallelGateway', inject(function(
+        popupMenu, elementRegistry) {
 
-    // given
-    const subProcess = elementRegistry.get('SubProcess_2');
+      // given
+      const parallelGateway = elementRegistry.get('ParallelGateway_1');
 
-    openPopup(subProcess);
+      openPopup(parallelGateway);
 
-    const collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
-          eventSubProcessEntry = queryEntry(popupMenu, 'replace-with-event-subprocess'),
-          sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
-          parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
+      const exclusiveGatewayEntry = queryEntry(popupMenu, 'replace-with-exclusive-gateway'),
+            eventBasedGatewayEntry = queryEntry(popupMenu, 'replace-with-event-based-gateway');
 
-    // then
-    expect(collapsedSubProcessEntry).to.exist;
-    expect(eventSubProcessEntry).to.exist;
-    expect(sequentialMultiInstanceEntry).to.exist;
-    expect(parallelMultiInstanceEntry).to.exist;
-  }));
+      // then
+      expect(exclusiveGatewayEntry).to.exist;
+      expect(eventBasedGatewayEntry).to.exist;
+    }));
+
+
+    it('should contain options for ExclusiveGateway', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const exclusiveGateway = elementRegistry.get('ExclusiveGateway_1');
+
+      openPopup(exclusiveGateway);
+
+      const parallelGatewayEntry = queryEntry(popupMenu, 'replace-with-parallel-gateway'),
+            eventBasedGatewayEntry = queryEntry(popupMenu, 'replace-with-event-based-gateway');
+
+      // then
+      expect(parallelGatewayEntry).to.exist;
+      expect(eventBasedGatewayEntry).to.exist;
+    }));
+
+  });
+
+
+  describe('sub processes', function() {
+
+    it('should contain options for (collapsed) SubProcess', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const subProcess = elementRegistry.get('SubProcess_1');
+
+      openPopup(subProcess);
+
+      const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
+            receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
+            serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
+            expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
+            sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
+            parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
+
+      // then
+      expect(taskEntry).to.exist;
+      expect(serviceTaskEntry).to.exist;
+      expect(expandedSubProcessEntry).to.exist;
+      expect(receiveTaskEntry).to.exist;
+      expect(sequentialMultiInstanceEntry).to.exist;
+      expect(parallelMultiInstanceEntry).to.exist;
+    }));
+
+
+    it('should contain options for (expanded) SubProcess', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const subProcess = elementRegistry.get('SubProcess_2');
+
+      openPopup(subProcess);
+
+      const collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
+            eventSubProcessEntry = queryEntry(popupMenu, 'replace-with-event-subprocess'),
+            sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
+            parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
+
+      // then
+      expect(collapsedSubProcessEntry).to.exist;
+      expect(eventSubProcessEntry).to.exist;
+      expect(sequentialMultiInstanceEntry).to.exist;
+      expect(parallelMultiInstanceEntry).to.exist;
+    }));
+
+  });
 
 
   describe('participants', function() {

--- a/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
+++ b/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
@@ -291,6 +291,40 @@ describe('customs - replaceMenu', function() {
   }));
 
 
+  describe('participants', function() {
+
+    it('should contain options for  (expanded) Participant', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const participant = elementRegistry.get('Participant_1');
+
+      openPopup(participant);
+
+      const collapseEntry = queryEntry(popupMenu, 'replace-with-collapsed-pool');
+
+      // then
+      expect(collapseEntry).to.exist;
+    }));
+
+
+    it('should contain options for  (collapsed) Participant', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const participant = elementRegistry.get('Participant_2');
+
+      openPopup(participant);
+
+      const expandEntry = queryEntry(popupMenu, 'replace-with-expanded-pool');
+
+      // then
+      expect(expandEntry).to.exist;
+    }));
+
+  });
+
+
   describe('event sub process', function() {
 
     it('should contain options for EventSubProcess', inject(function(

--- a/client/src/app/tabs/bpmn/custom/__tests__/diagram.bpmn
+++ b/client/src/app/tabs/bpmn/custom/__tests__/diagram.bpmn
@@ -32,6 +32,7 @@
     </bpmn:subProcess>
     <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="MessageTask_1" />
     <bpmn:sequenceFlow id="SequenceFlow_0bqiybf" sourceRef="EventBasedGateway_1" targetRef="MessageTask_2" />
+    <bpmn:task id="Task_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1lw37ec">
@@ -92,6 +93,9 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Participant_0f59i68_di" bpmnElement="Participant_2" isHorizontal="true">
         <dc:Bounds x="155" y="600" width="820" height="60" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_00x84jb_di" bpmnElement="Task_1">
+        <dc:Bounds x="469" y="330" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/client/src/app/tabs/bpmn/custom/__tests__/diagram.bpmn
+++ b/client/src/app/tabs/bpmn/custom/__tests__/diagram.bpmn
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0r13zjy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0-dev">
+  <bpmn:collaboration id="Collaboration_1lw37ec">
+    <bpmn:participant id="Participant_1" processRef="Process_1" />
+    <bpmn:participant id="Participant_2" />
+  </bpmn:collaboration>
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="foo" />
     <bpmn:serviceTask id="ServiceTask_1" />
     <bpmn:receiveTask id="MessageTask_1" />
-    <bpmn:subProcess id="SubProcess_1" />
     <bpmn:endEvent id="EndEvent_1" />
     <bpmn:intermediateCatchEvent id="TimerEvent_1">
       <bpmn:timerEventDefinition>
@@ -14,7 +17,6 @@
     <bpmn:intermediateCatchEvent id="MessageEvent_1">
       <bpmn:messageEventDefinition />
     </bpmn:intermediateCatchEvent>
-    <bpmn:subProcess id="SubProcess_2" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1" />
     <bpmn:parallelGateway id="ParallelGateway_1" />
     <bpmn:eventBasedGateway id="EventBasedGateway_1">
@@ -23,65 +25,73 @@
     <bpmn:receiveTask id="MessageTask_2">
       <bpmn:incoming>SequenceFlow_0bqiybf</bpmn:incoming>
     </bpmn:receiveTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0bqiybf" sourceRef="EventBasedGateway_1" targetRef="MessageTask_2" />
+    <bpmn:subProcess id="SubProcess_1" />
+    <bpmn:subProcess id="SubProcess_2" />
     <bpmn:subProcess id="EventSubProcess1" triggeredByEvent="true">
       <bpmn:startEvent id="StartEvent_2" />
     </bpmn:subProcess>
     <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="MessageTask_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_0bqiybf" sourceRef="EventBasedGateway_1" targetRef="MessageTask_2" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1lw37ec">
+      <bpmndi:BPMNShape id="StartEvent_14qxzcb_di" bpmnElement="StartEvent_2">
+        <dc:Bounds x="612" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_1yykndx_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="155" y="58" width="820" height="510" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="159" y="92" width="36" height="36" />
+        <dc:Bounds x="209" y="92" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="169" y="133" width="16" height="14" />
+          <dc:Bounds x="219" y="133" width="16" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1enrqg1_di" bpmnElement="ServiceTask_1">
-        <dc:Bounds x="257" y="288" width="100" height="80" />
+        <dc:Bounds x="307" y="288" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ReceiveTask_1ynm5tw_di" bpmnElement="MessageTask_1">
-        <dc:Bounds x="257" y="82" width="100" height="80" />
+        <dc:Bounds x="307" y="82" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_1xr3isb_di" bpmnElement="SubProcess_1" isExpanded="false">
-        <dc:Bounds x="257" y="186" width="100" height="80" />
+        <dc:Bounds x="307" y="186" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1dzfqos_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="159" y="310" width="36" height="36" />
+        <dc:Bounds x="209" y="310" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_0yesqgt_di" bpmnElement="TimerEvent_1">
-        <dc:Bounds x="159" y="386" width="36" height="36" />
+        <dc:Bounds x="209" y="386" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_1onhsg6_di" bpmnElement="MessageEvent_1">
-        <dc:Bounds x="159" y="208" width="36" height="36" />
+        <dc:Bounds x="209" y="208" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_0n2mbjo_di" bpmnElement="SubProcess_2" isExpanded="true">
-        <dc:Bounds x="433" y="92" width="350" height="200" />
+        <dc:Bounds x="483" y="92" width="350" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1s9hr7o_di" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
-        <dc:Bounds x="267" y="403" width="50" height="50" />
+        <dc:Bounds x="317" y="403" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ParallelGateway_1s5grhk_di" bpmnElement="ParallelGateway_1">
-        <dc:Bounds x="347" y="403" width="50" height="50" />
+        <dc:Bounds x="397" y="403" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EventBasedGateway_10pzqj9_di" bpmnElement="EventBasedGateway_1">
-        <dc:Bounds x="267" y="479" width="50" height="50" />
+        <dc:Bounds x="317" y="479" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ReceiveTask_1tj6cz3_di" bpmnElement="MessageTask_2">
-        <dc:Bounds x="419" y="464" width="100" height="80" />
+        <dc:Bounds x="469" y="464" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0bqiybf_di" bpmnElement="SequenceFlow_0bqiybf">
-        <di:waypoint x="317" y="504" />
-        <di:waypoint x="419" y="504" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="SubProcess_0fxad2g_di" bpmnElement="EventSubProcess1" isExpanded="true">
-        <dc:Bounds x="540" y="340" width="360" height="200" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="StartEvent_14qxzcb_di" bpmnElement="StartEvent_2">
-        <dc:Bounds x="562" y="432" width="36" height="36" />
+        <dc:Bounds x="590" y="340" width="360" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BoundaryEvent_0be94jf_di" bpmnElement="BoundaryEvent_1">
-        <dc:Bounds x="292" y="144" width="36" height="36" />
+        <dc:Bounds x="342" y="144" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0bqiybf_di" bpmnElement="SequenceFlow_0bqiybf">
+        <di:waypoint x="367" y="504" />
+        <di:waypoint x="469" y="504" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0f59i68_di" bpmnElement="Participant_2" isHorizontal="true">
+        <dc:Bounds x="155" y="600" width="820" height="60" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/client/src/app/tabs/bpmn/custom/__tests__/diagram.bpmn
+++ b/client/src/app/tabs/bpmn/custom/__tests__/diagram.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0r13zjy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0r13zjy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0-dev">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="foo" />
     <bpmn:serviceTask id="ServiceTask_1" />
@@ -24,14 +24,17 @@
       <bpmn:incoming>SequenceFlow_0bqiybf</bpmn:incoming>
     </bpmn:receiveTask>
     <bpmn:sequenceFlow id="SequenceFlow_0bqiybf" sourceRef="EventBasedGateway_1" targetRef="MessageTask_2" />
-    <bpmn:subProcess id="EventSubProcess1" triggeredByEvent="true" />
+    <bpmn:subProcess id="EventSubProcess1" triggeredByEvent="true">
+      <bpmn:startEvent id="StartEvent_2" />
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="MessageTask_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="269" y="184" width="36" height="36" />
+        <dc:Bounds x="159" y="92" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="169" y="147" width="16" height="14" />
+          <dc:Bounds x="169" y="133" width="16" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1enrqg1_di" bpmnElement="ServiceTask_1">
@@ -73,6 +76,12 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="SubProcess_0fxad2g_di" bpmnElement="EventSubProcess1" isExpanded="true">
         <dc:Bounds x="540" y="340" width="360" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_14qxzcb_di" bpmnElement="StartEvent_2">
+        <dc:Bounds x="562" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_0be94jf_di" bpmnElement="BoundaryEvent_1">
+        <dc:Bounds x="292" y="144" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
+++ b/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
@@ -37,7 +37,9 @@ export const AVAILABLE_REPLACE_ELEMENTS = [
   'replace-with-subprocess',
   'replace-with-error-start',
   'replace-with-non-interrupting-message-start',
-  'replace-with-non-interrupting-timer-start'
+  'replace-with-non-interrupting-timer-start',
+  'replace-with-expanded-pool',
+  'replace-with-collapsed-pool'
 ];
 
 export const AVAILABLE_CONTEXTPAD_ENTRIES = [

--- a/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
+++ b/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
@@ -25,8 +25,11 @@ export const AVAILABLE_REPLACE_ELEMENTS = [
   'replace-with-message-boundary',
   'replace-with-event-based-gateway',
   'replace-with-receive-task',
+  'replace-with-task',
   'replace-with-message-start',
   'replace-with-timer-start',
+  'replace-with-none-intermediate-throw',
+  'replace-with-none-intermediate-throwing', // only for StartEvent
   'replace-with-non-interrupting-message-boundary',
   'replace-with-non-interrupting-timer-boundary',
   'replace-with-error-boundary',


### PR DESCRIPTION
This aligns the `ReplaceMenu` with the one of the Camunda Modeler. Furthermore, it adds missing replace options to ensure forward-and-backward type switching, e.g. in modeling events or tasks.

![Kapture 2019-10-11 at 10 47 48](https://user-images.githubusercontent.com/9433996/66638080-97b17000-ec14-11e9-89ea-b8f7d1febbcc.gif)

Additionally, it re-structures the overall test suite for the `ReplaceMenuProvider` and adds test coverage for several replace scenarios (e.g. boundary events, event-sub-processes, participants).

Closes #115 
