### PR TITLE
fix(client): remove props from business object if deleted in panel

### DIFF
--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/MultiInstanceLoopSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/MultiInstanceLoopSpec.js
@@ -167,17 +167,18 @@ describe('customs - multi instance loop', function() {
         triggerValue(input, 'foo', 'change');
       }));
 
-      it('should set input collection field as invalid', function() {
-
-        // when
-        triggerValue(input, '', 'change');
-
-        // then
-        expect(isInputInvalid(input)).to.be.true;
-      });
-
 
       describe('in the DOM', function() {
+
+        it('should set input collection field as invalid', function() {
+
+          // when
+          triggerValue(input, '', 'change');
+
+          // then
+          expect(isInputInvalid(input)).to.be.true;
+        });
+
 
         it('should execute', function() {
 
@@ -208,6 +209,16 @@ describe('customs - multi instance loop', function() {
 
 
         describe('on the business object', function() {
+
+          it('should remove', function() {
+
+            // when
+            triggerValue(input, '', 'change');
+
+            // then
+            expect(loopCharacteristics.inputCollection).not.to.exist;
+          });
+
 
           it('should execute', function() {
 
@@ -366,6 +377,16 @@ describe('customs - multi instance loop', function() {
 
         describe('on the business object', function() {
 
+          it('should remove', function() {
+
+            // when
+            triggerValue(input, '', 'change');
+
+            // then
+            expect(loopCharacteristics.inputElement).not.to.exist;
+          });
+
+
           it('should execute', function() {
 
             // then
@@ -523,6 +544,16 @@ describe('customs - multi instance loop', function() {
 
         describe('on the business object', function() {
 
+          it('should remove', function() {
+
+            // when
+            triggerValue(input, '', 'change');
+
+            // then
+            expect(loopCharacteristics.outputCollection).not.to.exist;
+          });
+
+
           it('should execute', function() {
 
             // then
@@ -679,6 +710,16 @@ describe('customs - multi instance loop', function() {
 
 
         describe('on the business object', function() {
+
+          it('should remove', function() {
+
+            // when
+            triggerValue(input, '', 'change');
+
+            // then
+            expect(loopCharacteristics.outputElement).not.to.exist;
+          });
+
 
           it('should execute', function() {
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/MultiInstanceLoopCharacteristics.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/MultiInstanceLoopCharacteristics.js
@@ -74,7 +74,11 @@ export default function(element, bpmnFactory, translate) {
 
     },
 
-    set: setProperties,
+    set: function(element, values) {
+      return setProperties(element, {
+        inputCollection: values.inputCollection || undefined
+      });
+    },
 
     validate: function(element, values) {
       const loopCharacteristics = getLoopCharacteristics(element),
@@ -110,7 +114,11 @@ export default function(element, bpmnFactory, translate) {
 
     },
 
-    set: setProperties
+    set: function(element, values) {
+      return setProperties(element, {
+        inputElement: values.inputElement || undefined
+      });
+    }
   }));
 
   // output collection ////////////////////////////////////////////////////////////
@@ -127,7 +135,11 @@ export default function(element, bpmnFactory, translate) {
 
     },
 
-    set: setProperties
+    set: function(element, values) {
+      return setProperties(element, {
+        outputCollection: values.outputCollection || undefined
+      });
+    },
   }));
 
   // output element //////////////////////////////////////////////////////
@@ -144,7 +156,11 @@ export default function(element, bpmnFactory, translate) {
 
     },
 
-    set: setProperties
+    set: function(element, values) {
+      return setProperties(element, {
+        outputElement: values.outputElement || undefined
+      });
+    },
   }));
 
   return entries;


### PR DESCRIPTION
Cf. Multi-Instance properties. Currently, these props will not be deleted when clicking the "X" removing button inside the properties panel. That leads to stuff like this.

```xml
<bpmn:serviceTask id="ServiceTask_06yk2gv">
      <bpmn:multiInstanceLoopCharacteristics>
        <bpmn:extensionElements>
          <zeebe:loopCharacteristics inputCollection="" inputElement="" outputCollection="" outputElement="" />
        </bpmn:extensionElements>
      </bpmn:multiInstanceLoopCharacteristics>
</bpmn:serviceTask>
```

Therefore this pull requests ensures the properties also got removed from the business object if deleted in the panel.


