### PR TITLE
Call Activity Support

### DIFF
--- a/client/src/app/tabs/bpmn/custom/CustomReplaceMenuProvider.js
+++ b/client/src/app/tabs/bpmn/custom/CustomReplaceMenuProvider.js
@@ -42,8 +42,12 @@ export default class CustomReplaceMenuProvider extends ReplaceMenuProvider {
     let headerEntries = [];
 
     if (
-      isAny(element, [ 'bpmn:ReceiveTask', 'bpmn:ServiceTask', 'bpmn:SubProcess' ]) &&
-      !isEventSubProcess(element)
+      isAny(element, [
+        'bpmn:ReceiveTask',
+        'bpmn:ServiceTask',
+        'bpmn:SubProcess',
+        'bpmn:CallActivity'
+      ]) && !isEventSubProcess(element)
     ) {
 
       const loopEntries = this._getLoopEntries(element);

--- a/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
+++ b/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
@@ -239,7 +239,9 @@ describe('customs - replaceMenu', function() {
             receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
             serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
             collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
-            expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess');
+            expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
+            sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
+            parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
       // then
       expect(taskEntry).to.exist;
@@ -247,6 +249,8 @@ describe('customs - replaceMenu', function() {
       expect(serviceTaskEntry).to.exist;
       expect(collapsedSubProcessEntry).to.exist;
       expect(expandedSubProcessEntry).to.exist;
+      expect(sequentialMultiInstanceEntry).to.exist;
+      expect(parallelMultiInstanceEntry).to.exist;
     }));
 
   });

--- a/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
+++ b/client/src/app/tabs/bpmn/custom/__tests__/CustomReplaceMenuProviderSpec.js
@@ -160,12 +160,14 @@ describe('customs - replaceMenu', function() {
 
       const messageTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
             serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
+            callActivityEntry = queryEntry(popupMenu, 'replace-with-call-activity'),
             collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
             expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess');
 
       // then
       expect(messageTaskEntry).to.exist;
       expect(serviceTaskEntry).to.exist;
+      expect(callActivityEntry).to.exist;
       expect(collapsedSubProcessEntry).to.exist;
       expect(expandedSubProcessEntry).to.exist;
     }));
@@ -181,6 +183,7 @@ describe('customs - replaceMenu', function() {
 
       const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
             serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
+            callActivityEntry = queryEntry(popupMenu, 'replace-with-call-activity'),
             collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
             expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
             sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
@@ -189,6 +192,7 @@ describe('customs - replaceMenu', function() {
       // then
       expect(taskEntry).to.exist;
       expect(serviceTaskEntry).to.exist;
+      expect(callActivityEntry).to.exist;
       expect(collapsedSubProcessEntry).to.exist;
       expect(expandedSubProcessEntry).to.exist;
       expect(sequentialMultiInstanceEntry).to.exist;
@@ -206,6 +210,7 @@ describe('customs - replaceMenu', function() {
 
       const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
             receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
+            callActivityEntry = queryEntry(popupMenu, 'replace-with-call-activity'),
             collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
             expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
             sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
@@ -214,10 +219,34 @@ describe('customs - replaceMenu', function() {
       // then
       expect(taskEntry).to.exist;
       expect(receiveTaskEntry).to.exist;
+      expect(callActivityEntry).to.exist;
       expect(collapsedSubProcessEntry).to.exist;
       expect(expandedSubProcessEntry).to.exist;
       expect(sequentialMultiInstanceEntry).to.exist;
       expect(parallelMultiInstanceEntry).to.exist;
+    }));
+
+
+    it('should contain options for CallActivity', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivity_1');
+
+      openPopup(callActivity);
+
+      const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
+            receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
+            serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
+            collapsedSubProcessEntry = queryEntry(popupMenu, 'replace-with-collapsed-subprocess'),
+            expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess');
+
+      // then
+      expect(taskEntry).to.exist;
+      expect(receiveTaskEntry).to.exist;
+      expect(serviceTaskEntry).to.exist;
+      expect(collapsedSubProcessEntry).to.exist;
+      expect(expandedSubProcessEntry).to.exist;
     }));
 
   });
@@ -291,15 +320,17 @@ describe('customs - replaceMenu', function() {
       const taskEntry = queryEntry(popupMenu, 'replace-with-task'),
             receiveTaskEntry = queryEntry(popupMenu, 'replace-with-receive-task'),
             serviceTaskEntry = queryEntry(popupMenu, 'replace-with-service-task'),
+            callActivityEntry = queryEntry(popupMenu, 'replace-with-call-activity'),
             expandedSubProcessEntry = queryEntry(popupMenu, 'replace-with-expanded-subprocess'),
             sequentialMultiInstanceEntry = queryEntry(popupMenu, 'toggle-parallel-mi'),
             parallelMultiInstanceEntry = queryEntry(popupMenu, 'toggle-sequential-mi');
 
       // then
       expect(taskEntry).to.exist;
-      expect(serviceTaskEntry).to.exist;
-      expect(expandedSubProcessEntry).to.exist;
       expect(receiveTaskEntry).to.exist;
+      expect(serviceTaskEntry).to.exist;
+      expect(callActivityEntry).to.exist;
+      expect(expandedSubProcessEntry).to.exist;
       expect(sequentialMultiInstanceEntry).to.exist;
       expect(parallelMultiInstanceEntry).to.exist;
     }));

--- a/client/src/app/tabs/bpmn/custom/__tests__/diagram.bpmn
+++ b/client/src/app/tabs/bpmn/custom/__tests__/diagram.bpmn
@@ -33,6 +33,7 @@
     <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="MessageTask_1" />
     <bpmn:sequenceFlow id="SequenceFlow_0bqiybf" sourceRef="EventBasedGateway_1" targetRef="MessageTask_2" />
     <bpmn:task id="Task_1" />
+    <bpmn:callActivity id="CallActivity_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1lw37ec">
@@ -40,7 +41,7 @@
         <dc:Bounds x="612" y="432" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Participant_1yykndx_di" bpmnElement="Participant_1" isHorizontal="true">
-        <dc:Bounds x="155" y="58" width="820" height="510" />
+        <dc:Bounds x="155" y="58" width="975" height="510" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="209" y="92" width="36" height="36" />
@@ -96,6 +97,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_00x84jb_di" bpmnElement="Task_1">
         <dc:Bounds x="469" y="330" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_1xv0tdl_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="910" y="180" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
+++ b/client/src/app/tabs/bpmn/custom/modeler-options/Options.js
@@ -39,7 +39,8 @@ export const AVAILABLE_REPLACE_ELEMENTS = [
   'replace-with-non-interrupting-message-start',
   'replace-with-non-interrupting-timer-start',
   'replace-with-expanded-pool',
-  'replace-with-collapsed-pool'
+  'replace-with-collapsed-pool',
+  'replace-with-call-activity'
 ];
 
 export const AVAILABLE_CONTEXTPAD_ENTRIES = [

--- a/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
@@ -42,6 +42,8 @@ import multiInstanceProps from './parts/MultiInstanceProps';
 
 import errorProps from './parts/ErrorProps';
 
+import callActivityProps from './parts/CallActivityProps';
+
 
 const getInputOutputParameterLabel = param => {
 
@@ -86,6 +88,7 @@ function createGeneralTabGroups(element, bpmnFactory, canvas, translate) {
   messageProps(detailsGroup, element, bpmnFactory, translate);
   timerProps(detailsGroup, element, bpmnFactory, translate);
   errorProps(detailsGroup, element, bpmnFactory, translate);
+  callActivityProps(detailsGroup, element, bpmnFactory, translate);
 
   const multiInstanceGroup = {
     id: 'multiInstance',

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/CallActivity.bpmn
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/CallActivity.bpmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0l1dxrj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0-dev">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:callActivity id="CallActivity_1">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="processId" processIdExpression="processIdExpression" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_empty" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="CallActivitiy_1_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="180" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_14j0m4l_di" bpmnElement="CallActivity_empty">
+        <dc:Bounds x="210" y="280" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/CallActivitySpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/CallActivitySpec.js
@@ -1,0 +1,506 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  bootstrapModeler,
+  inject
+} from 'bpmn-js/test/helper';
+
+import {
+  triggerValue
+} from './helper';
+
+import TestContainer from 'mocha-test-container-support';
+
+import propertiesPanelModule from 'bpmn-js-properties-panel';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+
+import coreModule from 'bpmn-js/lib/core';
+import selectionModule from 'diagram-js/lib/features/selection';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import propertiesProviderModule from '..';
+import zeebeModdleExtensions from '../../zeebe-bpmn-moddle/zeebe';
+
+const HIDE_CLASS = 'bpp-hidden';
+
+describe('customs - call activity', function() {
+
+  const diagramXML = require('./CallActivity.bpmn');
+
+  const testModules = [
+    coreModule, selectionModule, modelingModule,
+    propertiesPanelModule,
+    propertiesProviderModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+
+  beforeEach(inject(function(commandStack, propertiesPanel) {
+
+    const undoButton = document.createElement('button');
+    undoButton.textContent = 'UNDO';
+
+    undoButton.addEventListener('click', () => {
+      commandStack.undo();
+    });
+
+    container.appendChild(undoButton);
+
+    propertiesPanel.attachTo(container);
+  }));
+
+
+  describe('of processId', function() {
+
+    let bo;
+
+    describe('create', function() {
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_empty');
+        selection.select(shape);
+
+        bo = getBusinessObject(shape);
+
+        // assume
+        expect(getCalledElement(bo)).to.be.undefined;
+
+        const input = getInputField(
+          container,
+          'camunda-callActivity-processId',
+          'processId'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      it('should execute', function() {
+
+        // then
+        const calledElement = getCalledElement(bo);
+
+        expect(calledElement).to.exist;
+        expect(calledElement.processId).to.equal('foo');
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        const calledElement = getCalledElement(bo);
+
+        expect(calledElement).to.be.undefined;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        const calledElement = getCalledElement(bo);
+
+        expect(calledElement).to.exist;
+        expect(calledElement.processId).to.equal('foo');
+      }));
+
+    });
+
+
+    describe('update', function() {
+
+      let input, calledElement;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_1');
+        selection.select(shape);
+
+        const bo = getBusinessObject(shape);
+
+        calledElement = getCalledElement(bo);
+
+        input = getInputField(
+          container,
+          'camunda-callActivity-processId',
+          'processId'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          // then
+          expect(input.value).to.equal('foo');
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(input.value).to.equal('processId');
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(input.value).to.equal('foo');
+        }));
+
+
+        describe('on the business object', function() {
+
+          it('should remove', function() {
+
+            // when
+            triggerValue(input, '', 'change');
+
+            // then
+            expect(calledElement.processId).not.to.exist;
+          });
+
+
+          it('should execute', function() {
+
+            // then
+            expect(calledElement.processId).to.equal('foo');
+          });
+
+
+          it('should undo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+
+            // then
+            expect(calledElement.processId).to.equal('processId');
+          }));
+
+
+          it('should redo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+            commandStack.redo();
+
+            // then
+            expect(calledElement.processId).to.equal('foo');
+          }));
+
+        });
+
+      });
+
+    });
+
+  });
+
+
+  describe('of processIdExpression', function() {
+
+    let bo;
+
+    describe('create', function() {
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_empty');
+        selection.select(shape);
+
+        bo = getBusinessObject(shape);
+
+        // assume
+        expect(getCalledElement(bo)).to.be.undefined;
+
+        const input = getInputField(
+          container,
+          'camunda-callActivity-processIdExpression',
+          'processIdExpression'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      it('should execute', function() {
+
+        // then
+        const calledElement = getCalledElement(bo);
+
+        expect(calledElement).to.exist;
+        expect(calledElement.processIdExpression).to.equal('foo');
+      });
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        const calledElement = getCalledElement(bo);
+
+        expect(calledElement).to.be.undefined;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        const calledElement = getCalledElement(bo);
+
+        expect(calledElement).to.exist;
+        expect(calledElement.processIdExpression).to.equal('foo');
+      }));
+
+    });
+
+
+    describe('update', function() {
+
+      let input, calledElement;
+
+      beforeEach(inject(function(elementRegistry, selection) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_1');
+        selection.select(shape);
+
+        const bo = getBusinessObject(shape);
+
+        calledElement = getCalledElement(bo);
+
+        input = getInputField(
+          container,
+          'camunda-callActivity-processIdExpression',
+          'processIdExpression'
+        );
+
+        // when
+        triggerValue(input, 'foo', 'change');
+      }));
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          // then
+          expect(input.value).to.equal('foo');
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(input.value).to.equal('processIdExpression');
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(input.value).to.equal('foo');
+        }));
+
+
+        describe('on the business object', function() {
+
+          it('should remove', function() {
+
+            // when
+            triggerValue(input, '', 'change');
+
+            // then
+            expect(calledElement.processIdExpression).not.to.exist;
+          });
+
+
+          it('should execute', function() {
+
+            // then
+            expect(calledElement.processIdExpression).to.equal('foo');
+          });
+
+
+          it('should undo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+
+            // then
+            expect(calledElement.processIdExpression).to.equal('processIdExpression');
+          }));
+
+
+          it('should redo', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+            commandStack.redo();
+
+            // then
+            expect(calledElement.processIdExpression).to.equal('foo');
+          }));
+
+        });
+
+      });
+
+    });
+
+  });
+
+
+  describe('validation', function() {
+
+    let container, processIdInput, processIdExpressionInput;
+
+    beforeEach(inject(function(propertiesPanel, elementRegistry, selection) {
+
+      // given
+      container = propertiesPanel._container;
+
+      const shape = elementRegistry.get('CallActivity_empty');
+
+      // when
+      selection.select(shape);
+
+      processIdInput = getInputField(
+        container,
+        'camunda-callActivity-processId',
+        'processId'
+      );
+
+      processIdExpressionInput = getInputField(
+        container,
+        'camunda-callActivity-processIdExpression',
+        'processIdExpression'
+      );
+    }));
+
+    it('should show validation error', function() {
+
+      // then
+      expect(getErrorMessageEntry(container).className).not.to.contain(HIDE_CLASS);
+    });
+
+
+    it('should hide validation error when adding a process id', function() {
+
+      // when
+      triggerValue(processIdInput, 'foo', 'change');
+
+      // then
+      expect(getErrorMessageEntry(container).className).to.contain(HIDE_CLASS);
+    });
+
+
+    it('should hide validation error when adding a input id expression', function() {
+
+      // when
+      triggerValue(processIdExpressionInput, 'foo', 'change');
+
+      // then
+      expect(getErrorMessageEntry(container).className).to.contain(HIDE_CLASS);
+    });
+
+  });
+
+});
+
+
+// helper /////////
+
+const getCalledElement = (bo) => {
+
+  const extensions = extensionElementsHelper.getExtensionElements(
+    bo,
+    'zeebe:CalledElement'
+  );
+  return (extensions || [])[0];
+};
+
+const getGeneralTab = (container) => {
+  return domQuery('div[data-tab="general"]', container);
+};
+
+const getDetailsGroup = (container) => {
+  const tab = getGeneralTab(container);
+  return domQuery('div[data-group="details"]', tab);
+};
+
+const getEntry = (container, entryId) => {
+  return domQuery('div[data-entry="' + entryId + '"]', getDetailsGroup(container));
+};
+
+const getInputField = (container, entryId, inputName) => {
+  const selector = 'input' + (inputName ? '[name="' + inputName + '"]' : '');
+  return domQuery(selector, getEntry(container, entryId));
+};
+
+function getErrorMessageEntry(container) {
+  return getEntry(container, 'callActivity-errorMessage');
+}

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutput.bpmn
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutput.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.7.0-dev">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0-dev">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="ServiceTask_1">
       <bpmn:extensionElements>
@@ -16,6 +16,13 @@
       </bpmn:extensionElements>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="ServiceTask_empty" />
+    <bpmn:callActivity id="CallActivity_1" />
+    <bpmn:receiveTask id="ReceiveTask_1" />
+    <bpmn:subProcess id="SubProcess_1" />
+    <bpmn:intermediateCatchEvent id="MessageEvent_1">
+      <bpmn:messageEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:exclusiveGateway id="Gateway_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -24,6 +31,21 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0td0iog_di" bpmnElement="ServiceTask_empty">
         <dc:Bounds x="320" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_14nkjpp_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="160" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ReceiveTask_0mkif7n_di" bpmnElement="ReceiveTask_1">
+        <dc:Bounds x="320" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_1mpgqsq_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="160" y="360" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_0src8du_di" bpmnElement="MessageEvent_1">
+        <dc:Bounds x="474" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1pfdx83_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="555" y="255" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutputSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutputSpec.js
@@ -39,6 +39,8 @@ import modelingModule from 'bpmn-js/lib/features/modeling';
 import propertiesProviderModule from '..';
 import zeebeModdleExtensions from '../../zeebe-bpmn-moddle/zeebe';
 
+const HIDE_CLASS = 'bpp-hidden';
+
 describe('customs - input output property tab', function() {
 
   const diagramXML = require('./InputOutput.bpmn');
@@ -79,7 +81,7 @@ describe('customs - input output property tab', function() {
     propertiesPanel.attachTo(container);
   }));
 
-  it('should fetch empty list of input and output parameters', inject(function(propertiesPanel, selection, elementRegistry) {
+  it('should fetch empty list of input and output parameters', inject(function(selection, elementRegistry) {
 
     // given
     const shape = elementRegistry.get('ServiceTask_empty');
@@ -93,15 +95,15 @@ describe('customs - input output property tab', function() {
     selection.select(shape);
 
     // then
-    const inputsSelection = getInputParameterSelect(propertiesPanel._container);
+    const inputsSelection = getInputParameterSelect(container);
     expect(inputsSelection.options.length).to.equal(0);
 
-    const outputsSelection = getOutputParameterSelect(propertiesPanel._container);
+    const outputsSelection = getOutputParameterSelect(container);
     expect(outputsSelection.options.length).to.equal(0);
   }));
 
 
-  it('should fetch list of input parameters', inject(function(propertiesPanel, selection, elementRegistry) {
+  it('should fetch list of input parameters', inject(function(selection, elementRegistry) {
 
     // given
     const shape = elementRegistry.get('ServiceTask_1');
@@ -114,12 +116,12 @@ describe('customs - input output property tab', function() {
     selection.select(shape);
 
     // then
-    const inputsSelection = getInputParameterSelect(propertiesPanel._container);
+    const inputsSelection = getInputParameterSelect(container);
     expect(inputsSelection.options.length).to.equal(4);
   }));
 
 
-  it('should fetch list of output parameters', inject(function(propertiesPanel, selection, elementRegistry) {
+  it('should fetch list of output parameters', inject(function(selection, elementRegistry) {
 
     // given
     const shape = elementRegistry.get('ServiceTask_1');
@@ -132,9 +134,140 @@ describe('customs - input output property tab', function() {
     selection.select(shape);
 
     // then
-    const outputsSelection = getOutputParameterSelect(propertiesPanel._container);
+    const outputsSelection = getOutputParameterSelect(container);
     expect(outputsSelection.options.length).to.equal(4);
   }));
+
+
+  describe('availability', function() {
+
+    it('should display input and output parameters for ServiceTask', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_1');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const inputOutputTab = getInputOutputTab(container),
+              inputParameters = getInputParameterSelect(container),
+              outputParameters = getOutputParameterSelect(container);
+
+        expect(inputOutputTab).to.exist;
+        expect(inputParameters).to.exist;
+        expect(outputParameters).to.exist;
+      }
+    ));
+
+
+    it('should display input and output parameters for SubProcess', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('SubProcess_1');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const inputOutputTab = getInputOutputTab(container),
+              inputParameters = getInputParameterSelect(container),
+              outputParameters = getOutputParameterSelect(container);
+
+        expect(inputOutputTab).to.exist;
+        expect(inputParameters).to.exist;
+        expect(outputParameters).to.exist;
+      }
+    ));
+
+
+    it('should display input and output parameters for CallActivity', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_1');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const inputOutputTab = getInputOutputTab(container),
+              inputParameters = getInputParameterSelect(container),
+              outputParameters = getOutputParameterSelect(container);
+
+        expect(inputOutputTab).to.exist;
+        expect(inputParameters).to.exist;
+        expect(outputParameters).to.exist;
+      }
+    ));
+
+
+    it('should display output parameters for ReceiveTask', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('ReceiveTask_1');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const inputOutputTab = getInputOutputTab(container),
+              inputParameters = getInputParameterSelect(container),
+              outputParameters = getOutputParameterSelect(container);
+
+        expect(inputOutputTab).to.exist;
+        expect(inputParameters).not.to.exist;
+        expect(outputParameters).to.exist;
+      }
+    ));
+
+
+    it('should display output parameters for MessageEvent', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('MessageEvent_1');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const inputOutputTab = getInputOutputTab(container),
+              inputParameters = getInputParameterSelect(container),
+              outputParameters = getOutputParameterSelect(container);
+
+        expect(inputOutputTab).to.exist;
+        expect(inputParameters).not.to.exist;
+        expect(outputParameters).to.exist;
+      }
+    ));
+
+
+    it('should NOT display input and output parameters for Gateway', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('Gateway_1');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const inputOutputTab = getInputOutputTab(container),
+              inputParameters = getInputParameterSelect(container),
+              outputParameters = getOutputParameterSelect(container);
+
+        expect(inputOutputTab).to.exist;
+        expect(inputOutputTab.className).to.contain(HIDE_CLASS);
+        expect(inputParameters).not.to.exist;
+        expect(outputParameters).not.to.exist;
+      }
+    ));
+
+  });
 
 
   describe('property controls', function() {

--- a/client/src/app/tabs/bpmn/custom/properties-provider/helper/InputOutputHelper.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/helper/InputOutputHelper.js
@@ -9,9 +9,12 @@
  */
 
 import {
-  getBusinessObject,
-  is
+  getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  isAny
+} from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
 
 import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
 
@@ -107,8 +110,11 @@ export function isInputOutputSupported(element) {
    * @return {boolean} a boolean value
    */
 export function areInputParametersSupported(element) {
-  const bo = getBusinessObject(element);
-  return (is(bo, 'bpmn:ServiceTask') || is(bo, 'bpmn:SubProcess'));
+  return isAny(element, [
+    'bpmn:ServiceTask',
+    'bpmn:SubProcess',
+    'bpmn:CallActivity'
+  ]);
 }
 
 /**
@@ -119,13 +125,14 @@ export function areInputParametersSupported(element) {
    * @return {boolean} a boolean value
    */
 export function areOutputParametersSupported(element) {
-  const bo = getBusinessObject(element);
-  if (is(bo, 'bpmn:ServiceTask') || is(bo, 'bpmn:SubProcess') || is(bo, 'bpmn:ReceiveTask')) {
-    return true;
-  }
-
   const messageEventDefinition = eventDefinitionHelper.getMessageEventDefinition(element);
-  return messageEventDefinition;
+
+  return isAny(element, [
+    'bpmn:ServiceTask',
+    'bpmn:SubProcess',
+    'bpmn:ReceiveTask',
+    'bpmn:CallActivity'
+  ]) || messageEventDefinition;
 }
 
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/helper/__tests__/InputOutputHelperSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/helper/__tests__/InputOutputHelperSpec.js
@@ -1,0 +1,178 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  bootstrapModeler,
+  inject
+} from 'bpmn-js/test/helper';
+
+import coreModule from 'bpmn-js/lib/core';
+
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import {
+  areInputParametersSupported,
+  areOutputParametersSupported
+} from '../InputOutputHelper';
+
+describe('customs - input output helper', function() {
+
+  const diagramXML = require('./diagram.bpmn');
+
+  const testModules = [
+    coreModule,
+    modelingModule
+  ];
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: testModules,
+  }));
+
+  let createElement;
+
+  beforeEach(inject(function(elementFactory) {
+    createElement = (type, options) => {
+      const element = elementFactory.createShape({
+        type,
+        ...options
+      });
+
+      return element;
+    };
+  }));
+
+
+  describe('#areInputParametersSupported', function() {
+
+    it('should support ServiceTask', function() {
+
+      // given
+      const serviceTask = createElement('bpmn:ServiceTask');
+
+      // when
+      const supported = areInputParametersSupported(serviceTask);
+
+      // then
+      expect(supported).to.be.true;
+    });
+
+
+    it('should support SubProcess', function() {
+
+      // given
+      const subProcess = createElement('bpmn:SubProcess');
+
+      // when
+      const supported = areInputParametersSupported(subProcess);
+
+      // then
+      expect(supported).to.be.true;
+    });
+
+
+    it('should support CallActivity', function() {
+
+      // given
+      const callActivity = createElement('bpmn:CallActivity');
+
+      // when
+      const supported = areInputParametersSupported(callActivity);
+
+      // then
+      expect(supported).to.be.true;
+    });
+
+
+    it('should NOT support ReceiveTask', function() {
+
+      // given
+      const receiveTask = createElement('bpmn:ReceiveTask');
+
+      // when
+      const supported = areInputParametersSupported(receiveTask);
+
+      // then
+      expect(supported).to.be.false;
+    });
+
+  });
+
+
+  describe('#areOutputParametersSupported', function() {
+
+    it('should support ServiceTask', function() {
+
+      // given
+      const serviceTask = createElement('bpmn:ServiceTask');
+
+      // when
+      const supported = areOutputParametersSupported(serviceTask);
+
+      // then
+      expect(supported).to.be.true;
+    });
+
+
+    it('should support SubProcess', function() {
+
+      // given
+      const subProcess = createElement('bpmn:SubProcess');
+
+      // when
+      const supported = areOutputParametersSupported(subProcess);
+
+      // then
+      expect(supported).to.be.true;
+    });
+
+
+    it('should support CallActivity', function() {
+
+      // given
+      const callActivity = createElement('bpmn:CallActivity');
+
+      // when
+      const supported = areOutputParametersSupported(callActivity);
+
+      // then
+      expect(supported).to.be.true;
+    });
+
+
+    it('should support ReceiveTask', function() {
+
+      // given
+      const receiveTask = createElement('bpmn:ReceiveTask');
+
+      // when
+      const supported = areOutputParametersSupported(receiveTask);
+
+      // then
+      expect(supported).to.be.true;
+    });
+
+
+    it('should support MessageEvent', function() {
+
+      // given
+      const messageEvent = createElement('bpmn:IntermediateCatchEvent', {
+        eventDefinitionType: 'bpmn:MessageEventDefinition'
+      });
+
+      // when
+      const supported = areOutputParametersSupported(messageEvent);
+
+      // then
+      expect(!!supported).to.be.true;
+    });
+
+  });
+
+});

--- a/client/src/app/tabs/bpmn/custom/properties-provider/helper/__tests__/diagram.bpmn
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/helper/__tests__/diagram.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1y541f3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0-dev">
+  <bpmn:process id="Process_0pqrwsx" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_0s3qt91" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0pqrwsx">
+      <bpmndi:BPMNShape id="StartEvent_0s3qt91_di" bpmnElement="StartEvent_0s3qt91">
+        <dc:Bounds x="182" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/CallActivityProps.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/CallActivityProps.js
@@ -1,0 +1,155 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
+
+import cmdHelper from 'bpmn-js-properties-panel/lib/helper/CmdHelper';
+
+import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+
+import {
+  is,
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  classes as domClasses
+} from 'min-dom';
+
+import {
+  escapeHTML
+} from 'bpmn-js-properties-panel/lib/Utils';
+
+import entryFactory from 'bpmn-js-properties-panel/lib/factory/EntryFactory';
+
+export default function(group, element, bpmnFactory, translate) {
+
+  if (!is(element, 'bpmn:CallActivity')) {
+    return;
+  }
+
+  function getProperty(element, propertyName) {
+    const businessObject = getBusinessObject(element),
+          calledElement = getCalledElement(businessObject);
+
+    return calledElement ? calledElement.get(propertyName) : '';
+  }
+
+  function setProperties(element, values) {
+
+    const businessObject = getBusinessObject(element),
+          commands = [];
+
+    // ensure extensionElements
+    let extensionElements = businessObject.get('extensionElements');
+    if (!extensionElements) {
+      extensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, businessObject, bpmnFactory);
+      commands.push(cmdHelper.updateBusinessObject(element, businessObject, { extensionElements: extensionElements }));
+    }
+
+    // ensure zeebe:calledElement
+    let calledElement = getCalledElement(businessObject);
+    if (!calledElement) {
+      calledElement = elementHelper.createElement('zeebe:CalledElement', { }, extensionElements, bpmnFactory);
+      commands.push(cmdHelper.addAndRemoveElementsFromList(
+        element,
+        extensionElements,
+        'values',
+        'extensionElements',
+        [ calledElement ],
+        []
+      ));
+    }
+
+    // update properties
+    commands.push(cmdHelper.updateBusinessObject(element, calledElement, values));
+    return commands;
+  }
+
+
+  // validation /////////////////////////////////////////////////////////////////
+
+  group.entries.push({
+    id: 'callActivity-errorMessage',
+    html: `<div data-show="isInvalid">
+             <span class="bpp-icon-warning"></span>
+             ${escapeHTML(translate('Must either provide process id or process id expression'))}
+          </div>`,
+
+    isInvalid: function(element, node, notification) {
+
+      const businessObject = getBusinessObject(element),
+            calledElement = getCalledElement(businessObject);
+
+      let isInvalid = true;
+      if (calledElement) {
+        const processId = getProperty(element, 'processId'),
+              processIdExpression = getProperty(element, 'processIdExpression');
+
+        isInvalid = !processId && !processIdExpression;
+      }
+
+      domClasses(node).toggle('bpp-hidden', !isInvalid);
+      domClasses(notification).toggle('bpp-error-message', isInvalid);
+
+      return isInvalid;
+    }
+  });
+
+
+  // properties /////////////////////////////////////////////////////////////////
+
+  group.entries.push(entryFactory.textField({
+    id: 'process-id',
+    label: translate('Process Id'),
+    modelProperty: 'processId',
+
+    get: function(element) {
+      return {
+        processId: getProperty(element, 'processId')
+      };
+    },
+
+    set: function(element, values) {
+      return setProperties(element, {
+        processId: values.processId || undefined
+      });
+    }
+  }));
+
+  group.entries.push(entryFactory.textField({
+    id: 'processIdExpression',
+    label: translate('Process Id Expression'),
+    modelProperty: 'processIdExpression',
+
+    get: function(element) {
+      return {
+        processIdExpression: getProperty(element, 'processIdExpression')
+      };
+    },
+
+    set: function(element, values) {
+      return setProperties(element, {
+        processIdExpression: values.processIdExpression || undefined
+      });
+    }
+  }));
+}
+
+// helper //////////
+
+function getCalledElement(bo) {
+  const elements = getExtensionElements(bo, 'zeebe:CalledElement') || [];
+  return elements[0];
+}
+
+function getExtensionElements(bo, type) {
+  return extensionElementsHelper.getExtensionElements(bo, type);
+}

--- a/client/src/app/tabs/bpmn/custom/zeebe-bpmn-moddle/zeebe.json
+++ b/client/src/app/tabs/bpmn/custom/zeebe-bpmn-moddle/zeebe.json
@@ -197,6 +197,29 @@
           "isAttr": true
         }
       ]
+    },
+    {
+      "name": "CalledElement",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:CallActivity"
+        ]
+      },
+      "properties": [
+        {
+          "name": "processId",
+          "type": "string",
+          "isAttr": true
+        },
+        {
+          "name": "processIdExpression",
+          "type": "string",
+          "isAttr": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #118 

![Kapture 2019-10-17 at 10 00 51](https://user-images.githubusercontent.com/9433996/66989707-2c104c80-f0c5-11e9-8178-291cc8a00d04.gif)

____

Note: We now implement the first round for the properties, which includes _two_ input fields for the `processId` and `processIdExpression`. We will improve this by having _only one_ input field in a follow-up task: cf. https://github.com/zeebe-io/zeebe-modeler/issues/130