### PR TITLE
chore(sync-fork): add plugins folder to excluded directories

### DIFF
--- a/tasks/sync-fork.js
+++ b/tasks/sync-fork.js
@@ -379,7 +379,8 @@ async function sync(options) {
         'client/test/mocks/cmmn-js/',
         'client/test/mocks/dmn-js/',
         'client/src/app/tabs/bpmn/modeler/features/apply-default-templates/',
-        'client/src/app/tabs/bpmn/util/**/*namespace*'
+        'client/src/app/tabs/bpmn/util/**/*namespace*',
+        'client/src/plugins/',
       ]
     });
 


### PR DESCRIPTION
Related to #126

In order we want to pull in the latest Camunda Modeler changes, this PR add the `plugins` folder from the excluded directories while the synchronization. This will prevent the `deployment-tool` to be added to the Zeebe Modeler.

Tested it with an example synchronization

```js
$ npm run sync -- -t 3.4.1
```
