### PR TITLE
test(properties-provider): add test coverage for timer event definitions

### DIFF
--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/BoundaryEventTimerEventDefinition.bpmn
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/BoundaryEventTimerEventDefinition.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.16.2">
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.9.0-dev">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:task id="Task_16h3hnp" />
     <bpmn:boundaryEvent id="WITHOUT_TYPE" cancelActivity="false" attachedToRef="Task_16h3hnp">
@@ -15,20 +15,26 @@
         <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">cycle</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="INTERRUPTED" attachedToRef="Task_16h3hnp">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_06j9mv7" />
+    </bpmn:boundaryEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Task_16h3hnp_di" bpmnElement="Task_16h3hnp">
-        <dc:Bounds x="487" y="119" width="100" height="80" />
+        <dc:Bounds x="157" y="119" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BoundaryEvent_083vfyy_di" bpmnElement="WITHOUT_TYPE">
-        <dc:Bounds x="485" y="181" width="36" height="36" />
+        <dc:Bounds x="155" y="181" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BoundaryEvent_00lsj0q_di" bpmnElement="TIME_DURATION">
-        <dc:Bounds x="532" y="181" width="36" height="36" />
+        <dc:Bounds x="202" y="181" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BoundaryEvent_1lo9ydh_di" bpmnElement="TIME_CYCLE">
-        <dc:Bounds x="569" y="132" width="36" height="36" />
+        <dc:Bounds x="239" y="132" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1dtfpje_di" bpmnElement="INTERRUPTED">
+        <dc:Bounds x="162" y="101" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/EventSubProcessTimerEventDefinitionSpec.bpmn
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/EventSubProcessTimerEventDefinitionSpec.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_183z9t4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.9.0-dev">
+  <bpmn:process id="Process_1y6h5pa" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_0m4iqsu" triggeredByEvent="true">
+      <bpmn:startEvent id="TIME_CYCLE" isInterrupting="false">
+        <bpmn:timerEventDefinition>
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">cycle</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="WITHOUT_TYPE" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1vah8rs" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="TIME_DURATION" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_05d77cc">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">duration</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="INTERRUPTED">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_182lj39" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1y6h5pa">
+      <bpmndi:BPMNShape id="SubProcess_1n6472y_di" bpmnElement="SubProcess_0m4iqsu" isExpanded="true">
+        <dc:Bounds x="155" y="80" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1oftja9_di" bpmnElement="TIME_CYCLE">
+        <dc:Bounds x="192" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1a89k6z_di" bpmnElement="WITHOUT_TYPE">
+        <dc:Bounds x="192" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_183w0qr_di" bpmnElement="TIME_DURATION">
+        <dc:Bounds x="282" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_007xj7u_di" bpmnElement="INTERRUPTED">
+        <dc:Bounds x="302" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/EventSubProcessTimerEventDefinitionSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/EventSubProcessTimerEventDefinitionSpec.js
@@ -94,9 +94,9 @@ function isInputHidden(node) {
   return isHidden(node.parentNode);
 }
 
-describe('boundary-event-timer-event-properties', function() {
+describe('event-sub-process-timer-start', function() {
 
-  const diagramXML = require('./BoundaryEventTimerEventDefinition.bpmn');
+  const diagramXML = require('./EventSubProcessTimerEventDefinitionSpec.bpmn');
 
   const testModules = [
     coreModule, selectionModule, modelingModule,
@@ -381,7 +381,6 @@ describe('boundary-event-timer-event-properties', function() {
 
     });
 
-
     describe('from timeCycle', function() {
 
       let timerDefinition;
@@ -395,7 +394,6 @@ describe('boundary-event-timer-event-properties', function() {
         const bo = getBusinessObject(shape);
         timerDefinition = eventDefinitionHelper.getTimerEventDefinition(bo);
       }));
-
 
       describe('to undefined', function() {
 
@@ -734,6 +732,7 @@ describe('boundary-event-timer-event-properties', function() {
 
   });
 
+
   describe('change timer definition', function() {
 
     let container;
@@ -912,6 +911,7 @@ describe('boundary-event-timer-event-properties', function() {
     });
 
   });
+
 
   describe('validation', function() {
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/TimerEventProps.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/TimerEventProps.js
@@ -40,6 +40,7 @@ export default function(group, element, bpmnFactory) {
   timerEventDefinitionImpl(group, bpmnFactory, timerEventDefinition, timerOptions);
 }
 
+
 // helper //////////
 
 const cancelActivity = (element) => {


### PR DESCRIPTION
Related to #156

I added some test cases to verify the new selection options for timer event definitions introduced by https://github.com/zeebe-io/zeebe-modeler/pull/157. 

(Simply forgot to check whether we added some tests for that while making the review...)
