### PR TITLE
Disable library validation for notarization

### DIFF
--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Closes #179

What causes #179 and why this fix works:
As mentioned [here by Apple](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_disable-library-validation), library validation prevents an app from loading frameworks, plug-ins, or libraries unless they’re either signed by Apple or signed with the same team ID as the app. Thats why the gRPC module caused problems in macOS environment. This fix simply disables the library validation feature using the related configuration.
