### PR TITLE
Save Tab before Deploy

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
@@ -19,10 +19,30 @@ import DeploymentPlugin from '../DeploymentPlugin';
 const DEPLOYMENT_CONFIG_KEY = 'deployment-tool';
 const ZEEBE_ENDPOINTS_CONFIG_KEY = 'zeebeEndpoints';
 
+const NOOP_TAB = {
+  file: {
+    path: 'testPath'
+  }
+};
+
 describe('<DeploymentPlugin>', () => {
 
   it('should render', () => {
     createDeploymentPlugin();
+  });
+
+
+  it('should save tab before deploy', async () => {
+
+    // given
+    const saveSpy = sinon.spy();
+    const { instance } = createDeploymentPlugin({ saveSpy });
+
+    // when
+    await instance.onIconClicked();
+
+    // then
+    expect(saveSpy).to.have.been.called;
   });
 
 
@@ -46,40 +66,40 @@ describe('<DeploymentPlugin>', () => {
   });
 
 
-  it('should be in modalVisible:true state when clicking on icon', () => {
+  it('should be in modalVisible:true state when clicking on icon', async () => {
 
     // given
     const { wrapper, instance } = createDeploymentPlugin();
 
     // when
-    instance.onIconClicked();
+    await instance.onIconClicked();
 
     // then
     expect(wrapper.state('modalVisible')).to.be.true;
   });
 
 
-  it('should be in modalVisible:false state when clicking on icon twice', () => {
+  it('should be in modalVisible:false state when clicking on icon twice', async () => {
 
     // given
     const { wrapper, instance } = createDeploymentPlugin();
 
     // when
-    instance.onIconClicked();
-    instance.onIconClicked();
+    await instance.onIconClicked();
+    await instance.onIconClicked();
 
     // then
     expect(wrapper.state('modalVisible')).to.be.false;
   });
 
 
-  it('should be in modalVisible:false state when closed', () => {
+  it('should be in modalVisible:false state when closed', async () => {
 
     // given
     const { wrapper, instance } = createDeploymentPlugin();
 
     // when
-    instance.closeModal();
+    await instance.closeModal();
 
     // then
     expect(wrapper.state('modalVisible')).to.be.false;
@@ -183,20 +203,6 @@ describe('<DeploymentPlugin>', () => {
   });
 
 
-  it('should save tab on deploy', async () => {
-
-    // given
-    const saveSpy = sinon.spy();
-    const { instance } = createDeploymentPlugin({ saveSpy });
-
-    // when
-    await instance.onDeploy({ deploymentName: 'testName' });
-
-    // then
-    expect(saveSpy).to.have.been.called;
-  });
-
-
   it('should display notification on deployment success', async () => {
 
     // given
@@ -205,6 +211,8 @@ describe('<DeploymentPlugin>', () => {
       deploymentSuccessful: true,
       displayNotificationSpy
     });
+
+    instance.activeTab = NOOP_TAB;
 
     // when
     await instance.onDeploy({ deploymentName: 'testName' });
@@ -223,6 +231,8 @@ describe('<DeploymentPlugin>', () => {
     // given
     const displayNotificationSpy = sinon.spy();
     const { instance } = createDeploymentPlugin({ displayNotificationSpy });
+
+    instance.activeTab = NOOP_TAB;
 
     // when
     await instance.onDeploy({ deploymentName: 'testName' });
@@ -243,6 +253,9 @@ describe('<DeploymentPlugin>', () => {
     const displayLogSpy = sinon.spy();
     const { instance } = createDeploymentPlugin({ displayLogSpy });
 
+    instance.activeTab = NOOP_TAB;
+
+
     // when
     await instance.onDeploy({ deploymentName: 'testName' });
 
@@ -254,14 +267,14 @@ describe('<DeploymentPlugin>', () => {
   });
 
 
-  it('should broadcast deploymentInitiated message when clicked on icon', () => {
+  it('should broadcast deploymentInitiated message when clicked on icon', async () => {
 
     // given
     const broadcastMessageSpy = sinon.spy();
     const { instance } = createDeploymentPlugin({ broadcastMessageSpy });
 
     // when
-    instance.onIconClicked();
+    await instance.onIconClicked();
 
     // then
     expect(broadcastMessageSpy).to.have.been.calledWith('deploymentInitiated');
@@ -294,13 +307,13 @@ describe('<DeploymentPlugin>', () => {
   });
 
 
-  it('should be in isStart:false state when deploy icon clicked', () => {
+  it('should be in isStart:false state when deploy icon clicked', async () => {
 
     // given
     const { instance } = createDeploymentPlugin();
 
     // when
-    instance.onIconClicked();
+    await instance.onIconClicked();
 
     // then
     expect(instance.state.isStart).to.be.false;
@@ -345,14 +358,14 @@ describe('<DeploymentPlugin>', () => {
   });
 
 
-  it('should have skipNotificationOnSuccess:false after clicking on icon', () => {
+  it('should have skipNotificationOnSuccess:false after clicking on icon', async () => {
 
     // given
     const { instance } = createDeploymentPlugin();
     instance.skipNotificationOnSuccess = true;
 
     // when
-    instance.onIconClicked();
+    await instance.onIconClicked();
 
     // then
     expect(instance.skipNotificationOnSuccess).to.be.false;
@@ -436,11 +449,7 @@ const createDeploymentPlugin = (params = {}) => {
       if (params.saveSpy) {
         params.saveSpy(value);
       }
-      return {
-        file: {
-          path: 'testPath'
-        }
-      };
+      return NOOP_TAB;
     }
   };
   const broadcastMessage = (msg) => {

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
@@ -93,8 +93,19 @@ export default class StartInstancePlugin extends PureComponent {
   }
 
   onIconClicked = async () => {
-    const saveResult = await this.props.triggerAction('save', { tab: this.activeTab });
-    const path = saveResult.file.path;
+    const savedTab = await this.props.triggerAction('save', { tab: this.activeTab });
+
+    // cancel action if save modal got canceled
+    if (!savedTab) {
+      return;
+    }
+
+    const {
+      file: tabFile,
+      name: tabName
+    } = savedTab;
+
+    const path = tabFile.path;
 
     const deploymentConfig = await this.getSavedDeploymentConfig();
 
@@ -116,7 +127,7 @@ export default class StartInstancePlugin extends PureComponent {
 
     const deploymentResult = await zeebeAPI.deploy({
       filePath: path,
-      name: deploymentConfig.deployment.name || withoutExtension(this.activeTab.name)
+      name: deploymentConfig.deployment.name || withoutExtension(tabName)
     });
 
     if (!deploymentResult.success) {

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
@@ -19,6 +19,14 @@ import StartInstancePlugin from '../StartInstancePlugin';
 const DEPLOYMENT_CONFIG_KEY = 'deployment-tool';
 const ZEEBE_ENDPOINTS_CONFIG_KEY = 'zeebeEndpoints';
 
+const SAVE_CANCEL_OPERATION = 'cancel';
+
+const NOOP_TAB = {
+  file: {
+    path: 'testPath'
+  }
+};
+
 describe('<StartInstancePlugin>', () => {
 
   it('should render', () => {
@@ -150,17 +158,33 @@ describe('<StartInstancePlugin>', () => {
   });
 
 
-  it('should save when icon clicked', () => {
+  it('should save when icon clicked', async () => {
 
     // given
     const triggerActionSpy = sinon.spy();
     const { instance } = createStartInstancePlugin({ triggerActionSpy });
 
     // when
-    instance.onIconClicked();
+    await instance.onIconClicked();
 
     // then
     expect(triggerActionSpy).to.have.been.calledWith('save');
+  });
+
+
+  it('should cancel if save was not successfull', async () => {
+
+    // given
+    const getConfigSpy = sinon.spy();
+    const saveActionResult = SAVE_CANCEL_OPERATION;
+
+    const { instance } = createStartInstancePlugin({ getConfigSpy, saveActionResult });
+
+    // when
+    await instance.onIconClicked();
+
+    // then
+    expect(getConfigSpy).to.not.have.been.called;
   });
 
 
@@ -419,11 +443,7 @@ const createStartInstancePlugin = (params = {}) => {
       params.triggerActionSpy(key);
     }
     if (key === 'save') {
-      return {
-        file: {
-          path: 'testPath'
-        }
-      };
+      return params.saveActionResult === SAVE_CANCEL_OPERATION ? null : NOOP_TAB;
     }
   };
   const subscribeToMessaging = (key) => {


### PR DESCRIPTION
This ensures we're saving tab changes before the Deployment Modal got opened.

Furthermore, it ensures we do not run into an error when we canceled the saving dialog on start instance feature (and deployment)

Closes #199
