### PR TITLE
Setup Windows CI for nightly & distro builds #2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,28 @@ jobs:
       script:
       - COVERAGE=1 npm run all -- --x64 --no-compress
       - npx codecov
-    - stage: "distro [windows+linux]"
+    - stage: "distro [linux]"
       os: linux
       services: docker
       language: generic
       script:
       - |
-        ENVS=`env | grep -iE '^(DEBUG|NODE_|ELECTRON_|NPM_|CI|TRAVIS|WIN_CSC_|CSC_|GH_|AWS_|BUILD_)([A-Z]|_)*=' | sed -n '/^[^\t]/s/=.*//p' | sed '/^$/d' | sed 's/^/-e /g' | tr '\n' ' '`
+        ENVS=`env | grep -iE '^(DEBUG|NODE_|ELECTRON_|NPM_|CI|TRAVIS|CSC_|GH_|AWS_|BUILD_)([A-Z]|_)*=' | sed -n '/^[^\t]/s/=.*//p' | sed '/^$/d' | sed 's/^/-e /g' | tr '\n' ' '`
         docker run $ENVS --rm \
           -v ${PWD}:/project \
           -v ~/.cache/electron:/root/.cache/electron \
           -v ~/.cache/electron-builder:/root/.cache/electron-builder \
           electronuserland/builder@sha256:b50e44a98ffe9f716b2f66c51b7898404670c8b74c8c3fc2b152c53f8af60513 \
-          /bin/bash -c "npm i && npm run build -- --win --linux --publish"
+          /bin/bash -c "npm i && npm run build -- --linux --publish"
+    - stage: "distro [windows]"
+      os: windows
+      node_js: lts/*
+      language: node_js
+      script:
+      - |
+        echo $WIN_CSC_LINK > cert.p12
+        certutil -p $WIN_CSC_KEY_PASSWORD -importpfx ./cert.p12
+        npm run build -- --win --publish --certificateFingerprint=$WIN_CSC_FINGERPRINT
     - stage: "distro [macos]"
       os: osx
       osx_image: xcode11.2
@@ -41,20 +50,30 @@ jobs:
         depth: false
       script:
       - npm run send-license-book-summary
-    - stage: "nightly build [windows+linux]"
+    - stage: "nightly build [linux]"
       os: linux
       services: docker
       language: generic
       script:
       - |
         git checkout -b build-nightly
-        ENVS=`env | grep -iE '^(DEBUG|NODE_|ELECTRON_|NPM_|CI|TRAVIS|WIN_CSC_|CSC_|GH_|AWS_|BUILD_)([A-Z]|_)*=' | sed -n '/^[^\t]/s/=.*//p' | sed '/^$/d' | sed 's/^/-e /g' | tr '\n' ' '`
+        ENVS=`env | grep -iE '^(DEBUG|NODE_|ELECTRON_|NPM_|CI|TRAVIS|CSC_|GH_|AWS_|BUILD_)([A-Z]|_)*=' | sed -n '/^[^\t]/s/=.*//p' | sed '/^$/d' | sed 's/^/-e /g' | tr '\n' ' '`
         docker run $ENVS --rm \
           -v ${PWD}:/project \
           -v ~/.cache/electron:/root/.cache/electron \
           -v ~/.cache/electron-builder:/root/.cache/electron-builder \
           electronuserland/builder@sha256:b50e44a98ffe9f716b2f66c51b7898404670c8b74c8c3fc2b152c53f8af60513 \
-          /bin/bash -c "npm i && npm run build -- --win --linux --nightly --publish"
+          /bin/bash -c "npm i && npm run build -- --linux --nightly --publish"
+    - stage: "nightly build [windows]"
+      os: windows
+      node_js: lts/*
+      language: node_js
+      script:
+      - |
+        git checkout -b build-nightly
+        echo $WIN_CSC_LINK > cert.p12
+        certutil -p $WIN_CSC_KEY_PASSWORD -importpfx ./cert.p12
+        npm run build -- --win --nightly --publish --certificateFingerprint=$WIN_CSC_FINGERPRINT
     - stage: "nightly build [macos]"
       os: osx
       osx_image: xcode11.2
@@ -72,14 +91,18 @@ before_cache:
   - rm -rf "$HOME/.cache/electron-builder/wine"
 
 stages:
-  - test
-  - name: "distro [windows+linux]"
+  - name: test
+  - name: "distro [linux]"
+    if: tag =~ ^v\d
+  - name: "distro [windows]"
     if: tag =~ ^v\d
   - name: "distro [macos]"
     if: tag =~ ^v\d
   - name: "post distro"
     if: tag =~ ^v\d
-  - name: "nightly build [windows+linux]"
+  - name: "nightly build [linux]"
+    if: type IN (cron)
+  - name: "nightly build [windows]"
     if: type IN (cron)
   - name: "nightly build [macos]"
     if: type IN (cron)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+node_js: lts/*
+language: node_js
+
+env:
+  global: 
+    - ELECTRON_CACHE=$HOME/.cache/electron
+    - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
+
 cache:
   directories:
     - "$HOME/.npm"
@@ -7,89 +15,63 @@ cache:
 jobs:
   include:
     - stage: test
-      node_js: lts/*
-      language: node_js
       script:
-      - COVERAGE=1 npm run all -- --x64 --no-compress
-      - npx codecov
-    - stage: "distro [linux]"
+      - |
+        COVERAGE=1 npm run all -- --x64 --no-compress
+        npx codecov
+    - stage: "distro"
+      name: "Build Linux distro"
       os: linux
-      services: docker
-      language: generic
       script:
       - npm run build -- --linux --publish
-    - stage: "distro [windows]"
+    - stage: "distro"
+      name: "Build Windows distro"
       os: windows
-      node_js: lts/*
-      language: node_js
       script:
       - |
         echo $WIN_CSC_LINK > cert.p12
         certutil -p $WIN_CSC_KEY_PASSWORD -importpfx ./cert.p12
         npm run build -- --win --publish --certificateFingerprint=$WIN_CSC_FINGERPRINT
-    - stage: "distro [macos]"
+    - stage: "distro"
+      name: "Build MacOS distro"
       os: osx
       osx_image: xcode11.2
-      node_js: lts/*
-      language: node_js
-      env:
-        - ELECTRON_CACHE=$HOME/.cache/electron
-        - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
-      script: npm run build -- --mac --publish
+      script: 
+      - npm run build -- --mac --publish
     - stage: "post distro"
-      node_js: lts/*
-      language: node_js
       git:
         depth: false
       script:
       - npm run send-license-book-summary
-    - stage: "nightly build [linux]"
-      os: linux
-      services: docker
-      language: generic
+    - stage: "nightly build"
+      name: "Build Linux nightly"
       script:
       - |
         git checkout -b build-nightly
         npm run build -- --linux --nightly --publish
-    - stage: "nightly build [windows]"
+    - stage: "nightly build"
+      name: "Build Windows nightly"
       os: windows
-      node_js: lts/*
-      language: node_js
       script:
       - |
         git checkout -b build-nightly
         echo $WIN_CSC_LINK > cert.p12
         certutil -p $WIN_CSC_KEY_PASSWORD -importpfx ./cert.p12
         npm run build -- --win --nightly --publish --certificateFingerprint=$WIN_CSC_FINGERPRINT
-    - stage: "nightly build [macos]"
+    - stage: "nightly build"
+      name: "Build MacOS nightly"
       os: osx
       osx_image: xcode11.2
-      node_js: lts/*
-      language: node_js
-      env:
-        - ELECTRON_CACHE=$HOME/.cache/electron
-        - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
       script:
       - |
         git checkout -b build-nightly
         npm run build -- --mac --nightly --publish
 
-before_cache:
-  - rm -rf "$HOME/.cache/electron-builder/wine"
-
 stages:
   - name: test
-  - name: "distro [linux]"
-    if: tag =~ ^v\d
-  - name: "distro [windows]"
-    if: tag =~ ^v\d
-  - name: "distro [macos]"
+  - name: "distro"
     if: tag =~ ^v\d
   - name: "post distro"
     if: tag =~ ^v\d
-  - name: "nightly build [linux]"
-    if: type IN (cron)
-  - name: "nightly build [windows]"
-    if: type IN (cron)
-  - name: "nightly build [macos]"
+  - name: "nightly build"
     if: type IN (cron)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,7 @@ jobs:
       services: docker
       language: generic
       script:
-      - |
-        ENVS=`env | grep -iE '^(DEBUG|NODE_|ELECTRON_|NPM_|CI|TRAVIS|CSC_|GH_|AWS_|BUILD_)([A-Z]|_)*=' | sed -n '/^[^\t]/s/=.*//p' | sed '/^$/d' | sed 's/^/-e /g' | tr '\n' ' '`
-        docker run $ENVS --rm \
-          -v ${PWD}:/project \
-          -v ~/.cache/electron:/root/.cache/electron \
-          -v ~/.cache/electron-builder:/root/.cache/electron-builder \
-          electronuserland/builder@sha256:b50e44a98ffe9f716b2f66c51b7898404670c8b74c8c3fc2b152c53f8af60513 \
-          /bin/bash -c "npm i && npm run build -- --linux --publish"
+      - npm run build -- --linux --publish
     - stage: "distro [windows]"
       os: windows
       node_js: lts/*
@@ -57,13 +50,7 @@ jobs:
       script:
       - |
         git checkout -b build-nightly
-        ENVS=`env | grep -iE '^(DEBUG|NODE_|ELECTRON_|NPM_|CI|TRAVIS|CSC_|GH_|AWS_|BUILD_)([A-Z]|_)*=' | sed -n '/^[^\t]/s/=.*//p' | sed '/^$/d' | sed 's/^/-e /g' | tr '\n' ' '`
-        docker run $ENVS --rm \
-          -v ${PWD}:/project \
-          -v ~/.cache/electron:/root/.cache/electron \
-          -v ~/.cache/electron-builder:/root/.cache/electron-builder \
-          electronuserland/builder@sha256:b50e44a98ffe9f716b2f66c51b7898404670c8b74c8c3fc2b152c53f8af60513 \
-          /bin/bash -c "npm i && npm run build -- --linux --nightly --publish"
+        npm run build -- --linux --nightly --publish
     - stage: "nightly build [windows]"
       os: windows
       node_js: lts/*

--- a/tasks/distro.js
+++ b/tasks/distro.js
@@ -93,6 +93,10 @@ const signingOptions = [
   `-c.forceCodeSigning=${false}`
 ];
 
+if (argv.certificateFingerprint) {
+  signingOptions.push(`-c.win.certificateSha1=${argv.certificateFingerprint}`);
+}
+
 if (publish && (argv.ia32 || argv.x64)) {
   console.error('Do not override arch; is manually pinned');
   process.exit(1);


### PR DESCRIPTION
This sets up Windows CI on Travis for both distro and nightly builds. To select proper certificate, we use the cert's fingerprint as the cert subject apparently did not work (cf. https://travis-ci.com/github/zeebe-io/zeebe-modeler/jobs/319668343#L338).

Closes #192

Proof it builds: https://travis-ci.com/github/zeebe-io/zeebe-modeler/jobs/319688610

Implements https://github.com/zeebe-io/zeebe-modeler/pull/207 reverted by mistake.