### PR TITLE
chore(docs): update release email template link

### DIFF
--- a/docs/.project/RELEASE_CHECKLIST.md
+++ b/docs/.project/RELEASE_CHECKLIST.md
@@ -23,7 +23,7 @@ __Hint:__ Create a release issue and copy the template below into it.
 * [ ] Publish release on [Github Releases](https://github.com/zeebe-io/zeebe-modeler/releases)
 * [ ] write blog post on [Zeebe Blog](https://github.com/zeebe-io/zeebe.io/tree/master/content/blog), if applicable
 * [ ] spread the word
-    * [ ] send [release notice email](https://github.com/bpmn-io/internal-docs/blob/master/camunda-modeler/README.md#release-notice-email)
+    * [ ] send [release notice email](https://github.com/bpmn-io/internal-docs/blob/master/zeebe-modeler/README.md#release-notice-email)
     * [ ] tweet
 * [ ] Close [current milestone](https://github.com/zeebe-io/zeebe-modeler/milestones), if it exists
 ```


### PR DESCRIPTION
Closes https://github.com/zeebe-io/zeebe-modeler/issues/219

Requires https://github.com/bpmn-io/internal-docs/pull/110
