### PR TITLE
Improve sync script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -598,6 +598,21 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
+    "@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
+    },
     "@lerna/add": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.20.0.tgz",
@@ -13373,12 +13388,14 @@
       "dev": true
     },
     "simple-git": {
-      "version": "1.132.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
-      "integrity": "sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.20.1.tgz",
+      "integrity": "sha512-aa9s2ZLjXlHCVGbDXQLInMLvLkxKEclqMU9X5HMXi3tLWLxbWObz1UgtyZha6ocHarQtFp0OjQW9KHVR1g6wbA==",
       "dev": true,
       "requires": {
-        "debug": "^4.0.1"
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.1.1"
       }
     },
     "sinon": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
     "proxyquire": "^2.1.1",
-    "simple-git": "^1.124.0",
+    "simple-git": "^2.20.1",
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
     "tar-stream": "^2.1.0",

--- a/tasks/sync-fork.js
+++ b/tasks/sync-fork.js
@@ -38,8 +38,7 @@ const {
   },
   default: {
     branch: CAMUNDA_MODELER_BRANCH,
-    help: false,
-    tag: false
+    help: false
   }
 });
 
@@ -241,12 +240,12 @@ async function excludeFilesFromMerge(options) {
 /**
  * $ git merge @upstream/@branch --no-commit --no-ff
  * Overall syncing procedure
- * @param {String} options.branch
- * @param {String} options.tag
- * @param {String} options.upstream
+ * @param {object} options
+ * @param {string} options.branch
+ * @param {string} options.tag
+ * @param {string} options.upstream
  */
 async function sync(options) {
-
   const {
     branch,
     tag,
@@ -254,7 +253,7 @@ async function sync(options) {
   } = options;
 
   // no need do especially declare upstream if tag is selected
-  let syncPath = tag || `${upstream}/${branch}`;
+  const syncPath = tag ? tag : `${upstream}/${branch}`;
 
   console.log(`Sync: Execute 'git merge --no-commit --no-ff ${syncPath}'.`);
 
@@ -327,30 +326,32 @@ async function run(options) {
     tag
   } = options;
 
+  const upstream = CAMUNDA_MODELER_UPSTREAM;
+
   console.log('##### Started syncing #####');
 
   const hasOrigin = await hasUpstream({
-    upstream: CAMUNDA_MODELER_UPSTREAM
+    upstream
   });
 
   if (!hasOrigin) {
     await createUpstream({
       repository: CAMUNDA_MODELER_REPOSITORY,
-      upstream: CAMUNDA_MODELER_UPSTREAM
+      upstream
     });
   }
 
   const originalTags = await listTags();
 
   await fetchUpstream({
-    upstream: CAMUNDA_MODELER_UPSTREAM
+    upstream
   });
 
   try {
     await sync({
       branch,
       tag,
-      upstream: CAMUNDA_MODELER_UPSTREAM
+      upstream
     });
   } catch (e) {
 

--- a/tasks/sync-fork.js
+++ b/tasks/sync-fork.js
@@ -238,7 +238,7 @@ async function excludeFilesFromMerge(options) {
 }
 
 /**
- * $ git merge @upstream/@branch --no-commit --no-ff
+ * $ git merge @upstream/@branch --no-commit --squash
  * Overall syncing procedure
  * @param {object} options
  * @param {string} options.branch
@@ -255,7 +255,7 @@ async function sync(options) {
   // no need do especially declare upstream if tag is selected
   const syncPath = tag ? tag : `${upstream}/${branch}`;
 
-  console.log(`Sync: Execute 'git merge --no-commit --no-ff ${syncPath}'.`);
+  console.log(`Sync: Execute 'git merge --no-commit --squash ${syncPath}'.`);
 
   const _success = async function(response) {
 
@@ -274,7 +274,7 @@ async function sync(options) {
   const mergeCmd = [
     'merge',
     '--no-commit',
-    '--no-ff',
+    '--squash',
     syncPath
   ];
 


### PR DESCRIPTION
* [x] Change merge strategy to squash
* [ ] Fetch only a single tag or branch from upstream repository, cf. https://stackoverflow.com/questions/45338495/fetch-a-single-tag-from-remote-repository

This is not implemented as I couldn't set it up correctly together with `git merge` (fetch with `--no-tags` made it impossible to refer to the tag later).

* [x] Make sure to remove upstream tags and branches after sync regardless if it was successful or not

This apparently works correctly after update of `simple-git`.

__Which issue does this PR address?__

Closes #247

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
