### PR TITLE
feat: support propagateAllChildVariables attribute on callActivities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the [Zeebe Modeler](https://github.com/zeebe-io/zeebe-mod
 
 ___Note:__ Yet to be released changes appear here._
 * `FEAT`: use improved I/O mapping component ([#265](https://github.com/zeebe-io/zeebe-modeler/issues/265)
+* `FEAT`: support and allow editing propagateAllChildVariables of CallActivities ([#252]https://github.com/zeebe-io/zeebe-modeler/Issues/252)
 
 ## 0.10.0
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12582,9 +12582,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.1.0.tgz",
-      "integrity": "sha512-gYjW2y71v4ioU/jWp83nFifIOz2HVWKak2LfT6CVRGoPTQfD1YeRBMP3ePpbCABJtYYbVU41KNmpGhSxMdqkCQ=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.2.0.tgz",
+      "integrity": "sha512-tAOq4k7GfofAZR00YNHafrqBmagfqdmDB9eMLrkCJZxTpLlWWX4HptGd3+JkkTtHKKaltQK4xdTbWkBbsST0Vg=="
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -34,7 +34,7 @@
     "saxen": "^8.1.2",
     "scroll-tabs": "^1.0.1",
     "sourcemapped-stacktrace": "^1.1.9",
-    "zeebe-bpmn-moddle": "^0.1.0"
+    "zeebe-bpmn-moddle": "^0.2.0"
   },
   "homepage": ".",
   "devDependencies": {

--- a/client/src/app/tabs/bpmn/custom/modeling/__tests__/CreateZeebeCallActivityBehaviorSpec.js
+++ b/client/src/app/tabs/bpmn/custom/modeling/__tests__/CreateZeebeCallActivityBehaviorSpec.js
@@ -1,0 +1,243 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  bootstrapModeler,
+  inject
+} from 'bpmn-js/test/helper';
+
+import {
+  find
+} from 'min-dash';
+
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import copyPasteModule from 'diagram-js/lib/features/copy-paste';
+import coreModule from 'bpmn-js/lib/core';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import customBehaviorModules from '..';
+
+import { getCalledElement, getCalledElements } from '../helper/CalledElementHelper';
+
+
+describe('features/modeling/behavior - create call activities', function() {
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  describe('populate propagateAllChildVariables', function() {
+
+    describe('when creating new shapes', function() {
+
+      const processDiagramXML = require('./process-empty.bpmn');
+
+      const testModules = [
+        coreModule,
+        modelingModule,
+        customBehaviorModules
+      ];
+
+      beforeEach(bootstrapModeler(processDiagramXML, {
+        modules: testModules,
+        moddleExtensions
+      }));
+
+
+      it('should execute when creating bpmn:CallActivity', inject(function(canvas,
+          modeling) {
+
+        // given
+        const rootElement = canvas.getRootElement();
+
+        // when
+        const newShape = modeling.createShape({ type: 'bpmn:CallActivity' }, { x: 100, y: 100 }, rootElement);
+
+        // then
+        const calledElementExtension = getCalledElement(newShape);
+
+        expect(calledElementExtension).to.exist;
+        expect(calledElementExtension.propagateAllChildVariables).to.be.false;
+      }));
+
+
+      it('should not execute when creating bpmn:Task', inject(function(canvas,
+          modeling) {
+
+        // given
+        const rootElement = canvas.getRootElement();
+
+        // when
+        const newShape = modeling.createShape({ type: 'bpmn:Task' }, { x: 100, y: 100 }, rootElement);
+
+        // then
+        const calledElementExtension = getCalledElement(newShape);
+
+        expect(calledElementExtension).to.be.undefined;
+      }));
+
+    });
+
+
+    describe('when copying bpmn:CallActivity', function() {
+
+      const processDiagramXML = require('./process-call-activities.bpmn');
+
+      const testModules = [
+        coreModule,
+        modelingModule,
+        customBehaviorModules,
+        copyPasteModule
+      ];
+
+      beforeEach(bootstrapModeler(processDiagramXML, {
+        modules: testModules,
+        moddleExtensions
+      }));
+
+
+      it('should re-use existing extensionElements', inject(function(canvas,
+          elementRegistry, copyPaste) {
+
+        // given
+        const rootElement = canvas.getRootElement();
+        const callActivity = elementRegistry.get('CallActivity_1');
+
+        // when
+        copyPaste.copy(callActivity);
+        const elements = copyPaste.paste({
+          element: rootElement,
+          point: {
+            x: 1000,
+            y: 1000
+          }
+        });
+
+        // then
+        const pastedCallActivity = find(elements, function(element) {
+          return is(element, 'bpmn:CallActivity');
+        });
+
+        const calledElementExtensions = getCalledElements(pastedCallActivity);
+
+        expect(calledElementExtensions.length).to.equal(1);
+      }));
+
+
+      it('should not alter existing propagateAllChildVariables attribute', inject(function(canvas,
+          elementRegistry, copyPaste) {
+
+        // given
+        const rootElement = canvas.getRootElement();
+        const callActivity = elementRegistry.get('CallActivity_1');
+
+        // when
+        copyPaste.copy(callActivity);
+        const elements = copyPaste.paste({
+          element: rootElement,
+          point: {
+            x: 1000,
+            y: 1000
+          }
+        });
+
+        // assume
+        const pastedCallActivity = find(elements, function(element) {
+          return is(element, 'bpmn:CallActivity');
+        });
+
+        const calledElementExtensions = getCalledElements(pastedCallActivity);
+
+        expect(calledElementExtensions.length).to.equal(1);
+
+        // then
+        const calledElementExtension = getCalledElement(pastedCallActivity);
+
+        expect(calledElementExtension).to.exist;
+        expect(calledElementExtension.propagateAllChildVariables).to.be.true;
+      }));
+
+
+      it('should not alter existing processRef attribute', inject(function(canvas,
+          elementRegistry, copyPaste) {
+
+        // given
+        const rootElement = canvas.getRootElement();
+        const callActivity = elementRegistry.get('CallActivity_1');
+
+        // when
+        copyPaste.copy(callActivity);
+        const elements = copyPaste.paste({
+          element: rootElement,
+          point: {
+            x: 1000,
+            y: 1000
+          }
+        });
+
+        // assume
+        const pastedCallActivity = find(elements, function(element) {
+          return is(element, 'bpmn:CallActivity');
+        });
+
+        const calledElementExtensions = getCalledElements(pastedCallActivity);
+
+        expect(calledElementExtensions.length).to.equal(1);
+
+        // then
+        const calledElementExtension = getCalledElement(pastedCallActivity);
+
+        expect(calledElementExtension).to.exist;
+        expect(calledElementExtension.processId).to.equal('ProcessRef_1');
+      }));
+
+
+      // a legacy CallActivity refers to a CallActivity which was created with
+      // a previous version and therefore does not have the propageteAllChildVariables
+      // attribute set yet
+      it('should not alter existing processRef attribute of legacy CallActivity', inject(function(canvas,
+          elementRegistry, copyPaste) {
+
+        // given
+        const rootElement = canvas.getRootElement();
+        const callActivity = elementRegistry.get('CallActivity_2');
+
+        // when
+        copyPaste.copy(callActivity);
+        const elements = copyPaste.paste({
+          element: rootElement,
+          point: {
+            x: 1000,
+            y: 1000
+          }
+        });
+
+        // assume
+        const pastedCallActivity = find(elements, function(element) {
+          return is(element, 'bpmn:CallActivity');
+        });
+
+        const calledElementExtensions = getCalledElements(pastedCallActivity);
+        expect(calledElementExtensions.length).to.equal(1);
+
+        // then
+        const calledElementExtension = getCalledElement(pastedCallActivity);
+        expect(calledElementExtension).to.exist;
+        expect(calledElementExtension.processId).to.equal('ProcessRef_2');
+      }));
+
+    });
+
+  });
+
+});

--- a/client/src/app/tabs/bpmn/custom/modeling/__tests__/UpdatePropagateAllChildVariablesBehaviorIntegrationSpec.js
+++ b/client/src/app/tabs/bpmn/custom/modeling/__tests__/UpdatePropagateAllChildVariablesBehaviorIntegrationSpec.js
@@ -1,0 +1,382 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  bootstrapModeler,
+  inject
+} from 'bpmn-js/test/helper';
+
+import { triggerEvent } from '../../properties-provider/__tests__/helper';
+
+import {
+  getOutputParameters,
+  getInputOutput
+} from '../../properties-provider/helper/InputOutputHelper';
+
+import { getCalledElement } from '../helper/CalledElementHelper';
+
+import TestContainer from 'mocha-test-container-support';
+
+import { query as domQuery } from 'min-dom';
+
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import propertiesPanelModule from 'bpmn-js-properties-panel';
+import propertiesProviderModule from '../../properties-provider';
+import selectionModule from 'diagram-js/lib/features/selection';
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import customBehaviorModules from '..';
+
+
+describe('features/modeling/behavior integrationTest - update propagateAllChildVariables attribute on call activities', function() {
+
+  const diagramXML = require('./process-call-activities.bpmn');
+
+  const testModules = [
+    coreModule,
+    modelingModule,
+    propertiesPanelModule,
+    propertiesProviderModule,
+    selectionModule,
+    customBehaviorModules
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+  beforeEach(inject(function(propertiesPanel) {
+    propertiesPanel.attachTo(container);
+  }));
+
+
+  describe('remove outputParameters', function() {
+
+
+    describe('when toggling on with outputParameters and inputParameters', function() {
+
+      let shape;
+
+
+      describe('<propagateAllChildVariables> explicitly set', function() {
+
+        beforeEach(inject(function(selection, elementRegistry) {
+
+          // given
+          shape = elementRegistry.get('CallActivity_3');
+
+          // when
+          selection.select(shape);
+          clickPropagateAllChildVariablesToggle(container);
+        }));
+
+
+        it('should execute', inject(function() {
+
+          // then
+          const outputParameters = getOutputParameters(shape);
+          expect(outputParameters.length).to.equal(0);
+        }));
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          const outputParameters = getOutputParameters(shape);
+          expect(outputParameters).to.exist;
+          expect(outputParameters.length).to.equal(1);
+        }));
+
+
+        it('should undo/redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          const outputParameters = getOutputParameters(shape);
+          expect(outputParameters.length).to.equal(0);
+        }));
+
+      });
+
+
+      describe('<propagateAllChildVariables> not explicitly set (legacy callActivity)', function() {
+
+        beforeEach(inject(function(selection, elementRegistry) {
+
+          // given
+          shape = elementRegistry.get('CallActivity_4');
+
+          // when
+          selection.select(shape);
+          clickPropagateAllChildVariablesToggle(container);
+        }));
+
+
+        it('should execute', inject(function() {
+
+          // then
+          const outputParameters = getOutputParameters(shape);
+          expect(outputParameters.length).to.equal(0);
+        }));
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          const outputParameters = getOutputParameters(shape);
+          expect(outputParameters).to.exist;
+          expect(outputParameters.length).to.equal(1);
+        }));
+
+
+        it('should undo/redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          const outputParameters = getOutputParameters(shape);
+          expect(outputParameters.length).to.equal(0);
+        }));
+
+      });
+
+    });
+
+  });
+
+
+  describe('remove iOMapping', function() {
+
+
+    describe('when toggling on with outputParameters', function() {
+
+      let shape;
+
+
+      describe('<propagateAllChildVariables> explicitly set', function() {
+
+        beforeEach(inject(function(selection, elementRegistry) {
+
+          // given
+          shape = elementRegistry.get('CallActivity_5');
+
+          // when
+          selection.select(shape);
+          clickPropagateAllChildVariablesToggle(container);
+        }));
+
+
+        it('should execute', inject(function() {
+
+          // then
+          const inputOutput = getInputOutput(shape);
+          expect(inputOutput).to.not.exist;
+        }));
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          const outputParameters = getOutputParameters(shape);
+          expect(outputParameters).to.exist;
+          expect(outputParameters.length).to.equal(1);
+
+          const inputOutput = getInputOutput(shape);
+          expect(inputOutput).to.exist;
+        }));
+
+
+        it('should undo/redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          const inputOutput = getInputOutput(shape);
+          expect(inputOutput).to.not.exist;
+        }));
+
+      });
+
+
+      describe('<propagateAllChildVariables> not explicitly set (legacy callActivity)', function() {
+
+        beforeEach(inject(function(selection, elementRegistry) {
+
+          // given
+          shape = elementRegistry.get('CallActivity_6');
+
+          // when
+          selection.select(shape);
+          clickPropagateAllChildVariablesToggle(container);
+        }));
+
+
+        it('should execute', inject(function() {
+
+          // then
+          const inputOutput = getInputOutput(shape);
+          expect(inputOutput).to.not.exist;
+        }));
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          const outputParameters = getOutputParameters(shape);
+          expect(outputParameters).to.exist;
+          expect(outputParameters.length).to.equal(1);
+
+          const inputOutput = getInputOutput(shape);
+          expect(inputOutput).to.exist;
+        }));
+
+
+        it('should undo/redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          const inputOutput = getInputOutput(shape);
+          expect(inputOutput).to.not.exist;
+        }));
+
+      });
+
+    });
+
+
+  });
+
+
+  describe('set propagateAllChildVariables to false', function() {
+
+
+    describe('when adding output parameters', function() {
+
+      let shape, calledElement;
+
+      beforeEach(inject(function(selection, elementRegistry) {
+
+        // given
+        shape = elementRegistry.get('CallActivity_7');
+        calledElement = getCalledElement(shape);
+
+        // assume
+        const inputOutput = getInputOutput(shape);
+        expect(inputOutput).to.not.exist;
+
+        // when
+        selection.select(shape);
+        clickAddOutputParameterButton(container);
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(calledElement.propagateAllChildVariables).to.equal(false);
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // assume
+        expect(calledElement.propagateAllChildVariables).to.equal(true);
+      }));
+
+
+      it('should undo/redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(calledElement.propagateAllChildVariables).to.equal(false);
+      }));
+
+    });
+
+  });
+
+});
+
+
+// helper /////////
+
+const getPropagateAllChildVariablesToggle = (container) => {
+  return domQuery('#output-propagate-all-toggle', container);
+};
+
+const clickPropagateAllChildVariablesToggle = (container) => {
+  const toggle = getPropagateAllChildVariablesToggle(container);
+  triggerEvent(toggle, 'click');
+};
+
+const getAddButton = (container) => {
+  return domQuery('button[data-action="createElement"].bpp-input-output__add', container);
+};
+
+const getAddOutputParameterButton = (container) => {
+  return getAddButton(getOutputParameterGroup(container));
+};
+
+const clickAddOutputParameterButton = (container) => {
+  const addButton = getAddOutputParameterButton(container);
+  triggerEvent(addButton, 'click');
+};
+
+const getInputOutputTab = (container) => {
+  return domQuery('div[data-tab="input-output"]', container);
+};
+
+const getParameterGroup = (type, container) => {
+  return domQuery(`div[data-group="${type}"]`, getInputOutputTab(container));
+};
+
+const getOutputParameterGroup = (container) => {
+  return getParameterGroup('output', container);
+};

--- a/client/src/app/tabs/bpmn/custom/modeling/__tests__/UpdatePropagateAllChildVariablesBehaviorSpec.js
+++ b/client/src/app/tabs/bpmn/custom/modeling/__tests__/UpdatePropagateAllChildVariablesBehaviorSpec.js
@@ -1,0 +1,222 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  bootstrapModeler,
+  inject
+} from 'bpmn-js/test/helper';
+
+import {
+  getOutputParameters,
+  getInputOutput
+} from '../../properties-provider/helper/InputOutputHelper';
+
+import { getCalledElement } from '../helper/CalledElementHelper';
+
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import customBehaviorModules from '..';
+
+
+describe('features/modeling/behavior - update propagateAllChildVariables attribute on call activities', function() {
+
+  const diagramXML = require('./process-call-activities.bpmn');
+
+  const testModules = [
+    coreModule,
+    modelingModule,
+    customBehaviorModules
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+
+  describe('remove outputParameters', function() {
+
+    let shape, context;
+
+    beforeEach(inject(function(elementRegistry, eventBus) {
+
+      // given
+      shape = elementRegistry.get('CallActivity_3');
+
+      context = {
+        context: {
+          element: shape,
+          properties: {
+            propagateAllChildVariables: true
+          }
+        }
+      };
+
+      // when
+      eventBus.fire('commandStack.properties-panel.update-businessobject.executed', context);
+    }));
+
+
+    it('should execute', inject(function() {
+
+      // then
+      const outputParameters = getOutputParameters(shape);
+      expect(outputParameters.length).to.equal(0);
+    }));
+
+
+    it('should undo', inject(function(eventBus) {
+
+      // when
+      eventBus.fire('commandStack.properties-panel.update-businessobject.reverted', context);
+
+      // then
+      const outputParameters = getOutputParameters(shape);
+      expect(outputParameters).to.exist;
+      expect(outputParameters.length).to.equal(1);
+    }));
+
+
+    it('should undo/redo', inject(function(eventBus) {
+
+      // when
+      eventBus.fire('commandStack.properties-panel.update-businessobject.reverted', context);
+      eventBus.fire('commandStack.properties-panel.update-businessobject.executed', context);
+
+      // then
+      const outputParameters = getOutputParameters(shape);
+      expect(outputParameters.length).to.equal(0);
+    }));
+
+  });
+
+
+  describe('remove iOMapping', function() {
+
+    let shape, context;
+
+    beforeEach(inject(function(eventBus, elementRegistry) {
+
+      // given
+      shape = elementRegistry.get('CallActivity_5');
+
+      context = {
+        context: {
+          element: shape,
+          properties: {
+            propagateAllChildVariables: true
+          }
+        }
+      };
+
+      // when
+      eventBus.fire('commandStack.properties-panel.update-businessobject.executed', context);
+    }));
+
+
+    it('should execute', inject(function() {
+
+      // then
+      const inputOutput = getInputOutput(shape);
+      expect(inputOutput).to.not.exist;
+    }));
+
+
+    it('should undo', inject(function(eventBus) {
+
+      // when
+      eventBus.fire('commandStack.properties-panel.update-businessobject.reverted', context);
+
+      // then
+      const outputParameters = getOutputParameters(shape);
+      expect(outputParameters).to.exist;
+      expect(outputParameters.length).to.equal(1);
+
+      const inputOutput = getInputOutput(shape);
+      expect(inputOutput).to.exist;
+    }));
+
+
+    it('should undo/redo', inject(function(eventBus) {
+
+      // when
+      eventBus.fire('commandStack.properties-panel.update-businessobject.reverted', context);
+      eventBus.fire('commandStack.properties-panel.update-businessobject.executed', context);
+
+      // then
+      const inputOutput = getInputOutput(shape);
+      expect(inputOutput).to.not.exist;
+    }));
+
+  });
+
+
+  describe('set propagateAllChildVariables to false', function() {
+
+    let shape, calledElement, context;
+
+    beforeEach(inject(function(eventBus, elementRegistry, elementFactory) {
+
+      // given
+      shape = elementRegistry.get('CallActivity_7');
+      calledElement = getCalledElement(shape);
+
+      context = {
+        context: {
+          element: shape,
+          objectsToAdd: [ elementFactory.createShape({ type: 'zeebe:Output' }) ]
+        }
+      };
+
+      // assume
+      const inputOutput = getInputOutput(shape);
+      expect(inputOutput).to.not.exist;
+
+      // when
+      eventBus.fire('commandStack.properties-panel.update-businessobject-list.executed', context);
+    }));
+
+
+    it('should execute', inject(function() {
+
+      // then
+      expect(calledElement.propagateAllChildVariables).to.equal(false);
+    }));
+
+
+    it('should undo', inject(function(eventBus) {
+
+      // when
+      eventBus.fire('commandStack.properties-panel.update-businessobject-list.reverted', context);
+
+      // assume
+      expect(calledElement.propagateAllChildVariables).to.equal(true);
+    }));
+
+
+    it('should undo/redo', inject(function(eventBus) {
+
+      // when
+      eventBus.fire('commandStack.properties-panel.update-businessobject-list.reverted', context);
+      eventBus.fire('commandStack.properties-panel.update-businessobject-list.executed', context);
+
+      // then
+      expect(calledElement.propagateAllChildVariables).to.equal(false);
+    }));
+
+  });
+
+});

--- a/client/src/app/tabs/bpmn/custom/modeling/__tests__/process-call-activities.bpmn
+++ b/client/src/app/tabs/bpmn/custom/modeling/__tests__/process-call-activities.bpmn
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="_exCZYNkaEeSskpe2jvwgcA" targetNamespace="http://activiti.org/bpmn" exporter="Zeebe Modeler" exporterVersion="0.11.0-dev.20201106" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="Process_1" isExecutable="false">
+    <bpmn2:callActivity id="CallActivity_1" name="CallActivity_1">
+      <bpmn2:extensionElements>
+        <zeebe:calledElement processId="ProcessRef_1" propagateAllChildVariables="true" />
+      </bpmn2:extensionElements>
+    </bpmn2:callActivity>
+    <bpmn2:callActivity id="CallActivity_2" name="CallActivity_2">
+      <bpmn2:extensionElements>
+        <zeebe:calledElement processId="ProcessRef_2" />
+      </bpmn2:extensionElements>
+    </bpmn2:callActivity>
+    <bpmn2:callActivity id="CallActivity_3" name="CallActivity_3">
+      <bpmn2:extensionElements>
+        <zeebe:calledElement processId="ProcessRef_3" propagateAllChildVariables="false" />
+        <zeebe:ioMapping>
+          <zeebe:input source="= source" target="target" />
+          <zeebe:output source="= source" target="target" />
+        </zeebe:ioMapping>
+      </bpmn2:extensionElements>
+    </bpmn2:callActivity>
+    <bpmn2:callActivity id="CallActivity_4" name="CallActivity_4">
+      <bpmn2:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="= source" target="target" />
+          <zeebe:output source="= source" target="target" />
+        </zeebe:ioMapping>
+        <zeebe:calledElement processId="ProcessRef_4" />
+      </bpmn2:extensionElements>
+    </bpmn2:callActivity>
+    <bpmn2:callActivity id="CallActivity_5" name="CallActivity_5">
+      <bpmn2:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="= source" target="target" />
+        </zeebe:ioMapping>
+        <zeebe:calledElement processId="ProcessRef_5" propagateAllChildVariables="false" />
+      </bpmn2:extensionElements>
+    </bpmn2:callActivity>
+    <bpmn2:callActivity id="CallActivity_6" name="CallActivity_6">
+      <bpmn2:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="= source" target="target" />
+        </zeebe:ioMapping>
+        <zeebe:calledElement processId="ProcessRef_6" />
+      </bpmn2:extensionElements>
+    </bpmn2:callActivity>
+    <bpmn2:callActivity id="CallActivity_7" name="CallActivity_7">
+      <bpmn2:extensionElements>
+        <zeebe:calledElement processId="ProcessRef_7" propagateAllChildVariables="true" />
+      </bpmn2:extensionElements>
+    </bpmn2:callActivity>
+    <bpmn2:callActivity id="CallActivity_8" name="CallActivity_8">
+      <bpmn2:extensionElements>
+        <zeebe:calledElement processId="CallActivity_8" />
+      </bpmn2:extensionElements>
+    </bpmn2:callActivity>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_18i25ls_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ukecvm_di" bpmnElement="CallActivity_2">
+        <dc:Bounds x="160" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05qfge3_di" bpmnElement="CallActivity_3">
+        <dc:Bounds x="160" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1h3scmg_di" bpmnElement="CallActivity_4">
+        <dc:Bounds x="160" y="450" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1tifp6n_di" bpmnElement="CallActivity_5">
+        <dc:Bounds x="160" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xf705v_di" bpmnElement="CallActivity_6">
+        <dc:Bounds x="160" y="680" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1f6a6en_di" bpmnElement="CallActivity_7">
+        <dc:Bounds x="160" y="800" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1vm96bw_di" bpmnElement="CallActivity_8">
+        <dc:Bounds x="160" y="910" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/client/src/app/tabs/bpmn/custom/modeling/behavior/CreateZeebeCallActivityBehavior.js
+++ b/client/src/app/tabs/bpmn/custom/modeling/behavior/CreateZeebeCallActivityBehavior.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
+
+import { getCalledElement } from '../helper/CalledElementHelper';
+
+import inherits from 'inherits';
+
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+const HIGH_PRIORITY = 15000;
+
+/**
+ * BPMN specific create zeebe call activity behavior
+ */
+export default function CreateZeebeCallActivityBehavior(
+    eventBus, bpmnFactory) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  /**
+   * add a zeebe:calledElement extensionElement with
+   * propagateAllChildVariables attribute = false when creating
+   * a bpmn:callActivity
+   */
+  this.postExecuted('shape.create', HIGH_PRIORITY, function(context) {
+    const {
+      shape
+    } = context;
+
+    if (!is(shape, 'bpmn:CallActivity')) {
+      return;
+    }
+
+    const bo = getBusinessObject(shape);
+
+    // Reuse ExtensionElement if existing
+    const extensionElements = bo.get('extensionElements') ||
+      elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, bo, bpmnFactory);
+
+    // Ensure we have a calledElement
+    let calledElement = getCalledElement(bo);
+
+    if (!calledElement) {
+      calledElement = bpmnFactory.create('zeebe:CalledElement', {});
+      calledElement.propagateAllChildVariables = false;
+
+      extensionElements.get('values').push(
+        calledElement
+      );
+
+      bo.extensionElements = extensionElements;
+
+      // Handle existing callActivities
+    } else if (!calledElement.hasOwnProperty('propagateAllChildVariables')) {
+      calledElement.propagateAllChildVariables = false;
+    }
+
+  }, true);
+}
+
+
+CreateZeebeCallActivityBehavior.$inject = [
+  'eventBus',
+  'bpmnFactory'
+];
+
+inherits(CreateZeebeCallActivityBehavior, CommandInterceptor);

--- a/client/src/app/tabs/bpmn/custom/modeling/behavior/UpdatePropagateAllChildVariablesBehavior.js
+++ b/client/src/app/tabs/bpmn/custom/modeling/behavior/UpdatePropagateAllChildVariablesBehavior.js
@@ -1,0 +1,171 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import inherits from 'inherits';
+
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  getCalledElement,
+  isPropagateAllChildVariables
+} from '../helper/CalledElementHelper';
+
+import {
+  getInputParameters,
+  getOutputParameters,
+  getInputOutput
+} from '../../properties-provider/helper/InputOutputHelper';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+const HIGH_PRIORITY = 15000;
+
+
+/**
+ * UpdatePropagateAllChildVariablesBehavior reacts to either (1) toggling on propagateAllChildVariables
+ * when there are outputParameters present or (2) to adding outputParameters when
+ * propagateAllChildVariables is set to true.
+ * It will ensure that the propagateAllChildVariables attribute on calledElement
+ * extensionElements for callActivities is always consistent with outputParameter mappings
+ */
+export default function UpdatePropagateAllChildVariablesBehavior(
+    eventBus) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  // Behavior when toggling propagateAllChildVariables /////////////////////////
+  /**
+   * remove outputParameters from zeebe:IoMapping when setting propgateAlLChildVariables
+   * to true in the proeprties panel
+   */
+  this.executed('properties-panel.update-businessobject' , HIGH_PRIORITY, function(context) {
+    const {
+      element,
+      properties
+    } = context;
+
+    // (1) Don't execute this behavior if we are not in a call activity or not
+    // have properties to update or not update the propagateAllChildVariables
+    // to false
+    if (!is(element, 'bpmn:CallActivity') ||
+        !properties ||
+        !!properties.propagateAllChildVariables === false) {
+      return;
+    }
+
+    // (2) Check whether we have outputParameters
+    const outputParameters = getOutputParameters(element),
+          inputParameters = getInputParameters(element);
+
+    if (!outputParameters ||
+      outputParameters.length === 0) {
+      return;
+    }
+
+    // (3) Store old outputParameters and remove them
+    context.oldOutputParameters = outputParameters;
+
+    const inputOutput = getInputOutput(element);
+    inputOutput.outputParameters = [];
+
+    // (4) if we also have no inputParameters, store IOMapping and remove it
+    if (!inputParameters || inputParameters.length === 0) {
+      const extensionElements = getBusinessObject(element).extensionElements;
+      context.oldExtensionElements = extensionElements.values;
+
+      extensionElements.values = extensionElements.values.filter(ele => ele.$type !== 'zeebe:IoMapping');
+    }
+  }, true);
+
+  // Revert behavior when toggling propagateAllChildVariables //////////////////
+  this.reverted('properties-panel.update-businessobject', HIGH_PRIORITY, function(context) {
+    const {
+      element,
+      oldOutputParameters,
+      oldExtensionElements
+    } = context;
+
+    // (1) Only intercept the revert, if the behavior became active
+    if (oldOutputParameters) {
+
+      // (2) If we removed the IOMapping, bring it back first
+      if (oldExtensionElements) {
+        const extensionElements = getBusinessObject(element).extensionElements;
+
+        extensionElements.values = oldExtensionElements;
+      }
+
+      // (3) Bring back the outputParameters
+      const inputOutput = getInputOutput(element);
+      inputOutput.outputParameters = oldOutputParameters;
+    }
+  }, true);
+
+
+  // Behavior when adding outputParameters ////////////////////////////////////
+  /**
+   * un-toggle propgateAlLChildVariables when adding output parameters
+   */
+  this.executed('properties-panel.update-businessobject-list' , HIGH_PRIORITY, function(context) {
+    const {
+      element,
+      objectsToAdd
+    } = context;
+
+
+    // (1) Exit if we are not in a CallActivity, not adding an OutputParameter or not
+    // having set propagateAllChildVariables to false
+    if (!is(element, 'bpmn:CallActivity') ||
+     !objectsToAdd ||
+     objectsToAdd.length === 0 ||
+     objectsToAdd.filter(obj => is(obj, 'zeebe:Output')).length === 0 ||
+    isPropagateAllChildVariables(element) === false) {
+      return;
+    }
+
+    // (2) Store the old propAllChildVariables value and update it then
+    const bo = getBusinessObject(element),
+          calledElement = getCalledElement(bo);
+
+    context.oldPropagateAllChildVariables = true;
+
+    calledElement.propagateAllChildVariables = false;
+  }, true);
+
+  // Revert behavior when adding outputParmaeters ////////////////////////////////////
+  this.reverted('properties-panel.update-businessobject-list' , HIGH_PRIORITY, function(context) {
+    const {
+      element,
+      oldPropagateAllChildVariables
+    } = context;
+
+    // (1) Only intercept the revert, if the behavior became active
+    if (oldPropagateAllChildVariables) {
+      const bo = getBusinessObject(element),
+            calledElement = getCalledElement(bo);
+
+      calledElement.propagateAllChildVariables = oldPropagateAllChildVariables;
+    }
+  }, true);
+
+
+}
+
+
+UpdatePropagateAllChildVariablesBehavior.$inject = [
+  'eventBus'
+];
+
+
+inherits(UpdatePropagateAllChildVariablesBehavior, CommandInterceptor);

--- a/client/src/app/tabs/bpmn/custom/modeling/behavior/index.js
+++ b/client/src/app/tabs/bpmn/custom/modeling/behavior/index.js
@@ -9,10 +9,17 @@
  */
 
 import CreateZeebeBoundaryEventBehavior from './CreateZeebeBoundaryEventBehavior';
+import CreateZeebeCallActivityBehavior from './CreateZeebeCallActivityBehavior';
+import UpdatePropagateAllChildVariablesBehavior from './UpdatePropagateAllChildVariablesBehavior';
+
 
 export default {
   __init__: [
-    'createZeebeBoundaryEventBehavior'
+    'createZeebeBoundaryEventBehavior',
+    'createZeebeCallActivityBehavior',
+    'updatePropagateAllChildVariablesBehavior'
   ],
-  createZeebeBoundaryEventBehavior: [ 'type', CreateZeebeBoundaryEventBehavior ]
+  createZeebeBoundaryEventBehavior: [ 'type', CreateZeebeBoundaryEventBehavior ],
+  createZeebeCallActivityBehavior: [ 'type', CreateZeebeCallActivityBehavior ],
+  updatePropagateAllChildVariablesBehavior: [ 'type', UpdatePropagateAllChildVariablesBehavior ]
 };

--- a/client/src/app/tabs/bpmn/custom/modeling/helper/CalledElementHelper.js
+++ b/client/src/app/tabs/bpmn/custom/modeling/helper/CalledElementHelper.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  getOutputParameters
+} from '../../properties-provider/helper/InputOutputHelper';
+
+import { getExtensionElements } from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+/**
+  * Determine default value for propagateAllChildVariables attribute
+  * @param {Object} element representing a bpmn:CallActivity
+  *
+  * @returns {boolean}
+  */
+function determinePropAllChildVariablesDefault(element) {
+  const outputParameters = getOutputParameters(element);
+
+  if (outputParameters) {
+    return (outputParameters.length > 0) ? false : true;
+  }
+}
+
+/**
+  * Get the 'zeebe:CalledElement' extension element for a given business Object
+  * @param {Object} bo businessObject
+  *
+  * @returns {Object} the calledElement Moddle Object or undefined if zeebe:CalledElement does not exist
+  */
+export function getCalledElement(element) {
+  const calledElements = getCalledElements(element);
+  return calledElements && calledElements[0];
+}
+
+export function getCalledElements(element) {
+  const bo = getBusinessObject(element);
+  const extElement = getExtensionElements(bo, 'zeebe:CalledElement');
+  return extElement;
+}
+
+/**
+  * Check whether the propagateAllChildVariables attribute is set on an element.
+  * Note that a default logic will be determine if it is not explicitly set.
+  * @param {Object} element
+  *
+  * @returns {boolean}
+  */
+export function isPropagateAllChildVariables(element) {
+  if (!is(element, 'bpmn:CallActivity')) {
+    return undefined;
+  }
+
+  const bo = getBusinessObject(element),
+        calledElement = getCalledElement(bo);
+
+  return calledElement && calledElement.hasOwnProperty('propagateAllChildVariables') ?
+    calledElement.get('propagateAllChildVariables') :
+    determinePropAllChildVariablesDefault(element);
+}

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutput.bpmn
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutput.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.11.0-dev.20201029">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.11.0-dev.20201105">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="ServiceTask_1">
       <bpmn:extensionElements>
@@ -38,6 +38,29 @@
       <bpmn:messageEventDefinition />
     </bpmn:intermediateCatchEvent>
     <bpmn:exclusiveGateway id="Gateway_1" />
+    <bpmn:callActivity id="CallActivity_2" name="CallActivity_2">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="true" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_3" name="CallActivity_3">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_4" name="CallActivity_4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_5" name="CallActivity_5">
+      <bpmn:extensionElements>
+        <zeebe:calledElement />
+        <zeebe:ioMapping>
+          <zeebe:output source="= source" target="target" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -53,6 +76,9 @@
       <bpmndi:BPMNShape id="ReceiveTask_0mkif7n_di" bpmnElement="ReceiveTask_1">
         <dc:Bounds x="320" y="240" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bi1uc7_di" bpmnElement="CallActivity_2">
+        <dc:Bounds x="780" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_1mpgqsq_di" bpmnElement="SubProcess_1" isExpanded="true">
         <dc:Bounds x="160" y="360" width="350" height="200" />
       </bpmndi:BPMNShape>
@@ -61,6 +87,15 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1pfdx83_di" bpmnElement="Gateway_1" isMarkerVisible="true">
         <dc:Bounds x="555" y="255" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05eq19r_di" bpmnElement="CallActivity_3">
+        <dc:Bounds x="940" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06orbnp_di" bpmnElement="CallActivity_4">
+        <dc:Bounds x="780" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0411avp_di" bpmnElement="CallActivity_5">
+        <dc:Bounds x="940" y="200" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutputSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutputSpec.js
@@ -37,10 +37,14 @@ import {
 } from 'min-dom';
 
 import coreModule from 'bpmn-js/lib/core';
-import selectionModule from 'diagram-js/lib/features/selection';
 import modelingModule from 'bpmn-js/lib/features/modeling';
+import propertiesPanelModule from 'bpmn-js-properties-panel';
 import propertiesProviderModule from '..';
+import selectionModule from 'diagram-js/lib/features/selection';
 import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import customBehaviorModules from '../../modeling';
+
 
 const HIDE_CLASS = 'bpp-hidden';
 
@@ -53,9 +57,10 @@ describe('customs - input output property tab', function() {
   const testModules = [
     coreModule,
     modelingModule,
-    selectionModule,
     propertiesPanelModule,
-    propertiesProviderModule
+    propertiesProviderModule,
+    selectionModule,
+    customBehaviorModules
   ];
 
   const moddleExtensions = {
@@ -73,76 +78,71 @@ describe('customs - input output property tab', function() {
     moddleExtensions
   }));
 
-  beforeEach(inject(function(commandStack, propertiesPanel) {
-
-    const undoButton = document.createElement('button');
-    undoButton.textContent = 'UNDO';
-
-    undoButton.addEventListener('click', () => {
-      commandStack.undo();
-    });
-
-    container.appendChild(undoButton);
-
+  beforeEach(inject(function(propertiesPanel) {
     propertiesPanel.attachTo(container);
   }));
 
-  it('should fetch empty list of input and output parameters', inject(function(selection, elementRegistry) {
 
-    // given
-    const shape = elementRegistry.get('ServiceTask_empty'),
-          bo = getBusinessObject(shape);
+  describe('fetch parameters', function() {
 
-    // assume
-    expect(getInputParameters(bo).length).to.equal(0);
-    expect(getOutputParameters(bo).length).to.equal(0);
+    it('should fetch empty list of input and output parameters', inject(function(selection, elementRegistry) {
 
-    // when
-    selection.select(shape);
+      // given
+      const shape = elementRegistry.get('ServiceTask_empty'),
+            bo = getBusinessObject(shape);
 
-    // then
-    const inputParameterEntries = getInputParameterCollapsibles(container);
-    expect(inputParameterEntries.length).to.equal(0);
+      // assume
+      expect(getInputParameters(bo).length).to.equal(0);
+      expect(getOutputParameters(bo).length).to.equal(0);
 
-    const outputParameterEntries = getOutputParameterCollapsibles(container);
-    expect(outputParameterEntries.length).to.equal(0);
-  }));
+      // when
+      selection.select(shape);
 
+      // then
+      const inputParameterEntries = getInputParameterCollapsibles(container);
+      expect(inputParameterEntries.length).to.equal(0);
 
-  it('should fetch list of input parameters', inject(function(selection, elementRegistry) {
-
-    // given
-    const shape = elementRegistry.get('ServiceTask_1'),
-          bo = getBusinessObject(shape);
-
-    // assume
-    expect(getInputParameters(bo).length).to.equal(4);
-
-    // when
-    selection.select(shape);
-
-    // then
-    const inputParameterEntries = getInputParameterCollapsibles(container);
-    expect(inputParameterEntries.length).to.equal(4);
-  }));
+      const outputParameterEntries = getOutputParameterCollapsibles(container);
+      expect(outputParameterEntries.length).to.equal(0);
+    }));
 
 
-  it('should fetch list of output parameters', inject(function(selection, elementRegistry) {
+    it('should fetch list of input parameters', inject(function(selection, elementRegistry) {
 
-    // given
-    const shape = elementRegistry.get('ServiceTask_1'),
-          bo = getBusinessObject(shape);
+      // given
+      const shape = elementRegistry.get('ServiceTask_1'),
+            bo = getBusinessObject(shape);
 
-    // assume
-    expect(getOutputParameters(bo).length).to.equal(4);
+      // assume
+      expect(getInputParameters(bo).length).to.equal(4);
 
-    // when
-    selection.select(shape);
+      // when
+      selection.select(shape);
 
-    // then
-    const outputParameterEntries = getOutputParameterCollapsibles(container);
-    expect(outputParameterEntries.length).to.equal(4);
-  }));
+      // then
+      const inputParameterEntries = getInputParameterCollapsibles(container);
+      expect(inputParameterEntries.length).to.equal(4);
+    }));
+
+
+    it('should fetch list of output parameters', inject(function(selection, elementRegistry) {
+
+      // given
+      const shape = elementRegistry.get('ServiceTask_1'),
+            bo = getBusinessObject(shape);
+
+      // assume
+      expect(getOutputParameters(bo).length).to.equal(4);
+
+      // when
+      selection.select(shape);
+
+      // then
+      const outputParameterEntries = getOutputParameterCollapsibles(container);
+      expect(outputParameterEntries.length).to.equal(4);
+    }));
+
+  });
 
 
   describe('availability', function() {
@@ -326,7 +326,6 @@ describe('customs - input output property tab', function() {
       }
     ));
 
-
   });
 
 
@@ -343,7 +342,9 @@ describe('customs - input output property tab', function() {
       selection.select(shape);
     }));
 
+
     describe('of input parameters', function() {
+
 
       it('should initially be collapsed for all', function() {
 
@@ -392,7 +393,6 @@ describe('customs - input output property tab', function() {
           }
         });
       });
-
 
     });
 
@@ -447,7 +447,6 @@ describe('customs - input output property tab', function() {
         });
       });
 
-
     });
 
   });
@@ -471,6 +470,7 @@ describe('customs - input output property tab', function() {
       clickAddInputParameterButton(container);
 
     }));
+
 
     describe('on the business object', function() {
 
@@ -500,7 +500,6 @@ describe('customs - input output property tab', function() {
         // then
         expect(getInputParameters(bo).length).to.equal(1);
       }));
-
 
     });
 
@@ -534,7 +533,6 @@ describe('customs - input output property tab', function() {
         expect(getInputParameterCollapsibles(container).length).to.equal(1);
       }));
 
-
     });
 
   });
@@ -564,6 +562,7 @@ describe('customs - input output property tab', function() {
       clickAddOutputParameterButton(container);
     }));
 
+
     describe('on the business object', function() {
 
       it('should execute', function() {
@@ -592,7 +591,6 @@ describe('customs - input output property tab', function() {
         // then
         expect(getOutputParameters(bo).length).to.equal(1);
       }));
-
 
     });
 
@@ -625,7 +623,6 @@ describe('customs - input output property tab', function() {
         // then
         expect(getOutputParameterCollapsibles(container).length).to.equal(1);
       }));
-
 
     });
 
@@ -703,7 +700,6 @@ describe('customs - input output property tab', function() {
         expect(getInputParameters(bo).length).to.equal(3);
       }));
 
-
     });
 
 
@@ -735,7 +731,6 @@ describe('customs - input output property tab', function() {
         // then
         expect(getInputParameterCollapsibles(container).length).to.equal(3);
       }));
-
 
     });
 
@@ -792,7 +787,6 @@ describe('customs - input output property tab', function() {
         expect(getOutputParameters(bo).length).to.equal(3);
       }));
 
-
     });
 
 
@@ -824,7 +818,6 @@ describe('customs - input output property tab', function() {
         // then
         expect(getOutputParameterCollapsibles(container).length).to.equal(3);
       }));
-
 
     });
 
@@ -881,13 +874,13 @@ describe('customs - input output property tab', function() {
         expect(getIOMapping(bo)).not.to.exist;
       }));
 
-
     });
-
 
   });
 
+
   describe('change parameter source', function() {
+
 
     describe('input', function() {
 
@@ -984,7 +977,6 @@ describe('customs - input output property tab', function() {
           expect(isInvalidInput(parameterSourceInput)).to.be.false;
         });
 
-
       });
 
 
@@ -1016,7 +1008,6 @@ describe('customs - input output property tab', function() {
           // then
           expect(parameter.source).to.equal('= foo');
         }));
-
 
       });
 
@@ -1117,7 +1108,6 @@ describe('customs - input output property tab', function() {
           expect(isInvalidInput(parameterSourceOutput)).to.be.false;
         });
 
-
       });
 
 
@@ -1150,7 +1140,6 @@ describe('customs - input output property tab', function() {
           expect(parameter.source).to.equal('= foo');
         }));
 
-
       });
 
     });
@@ -1159,6 +1148,7 @@ describe('customs - input output property tab', function() {
 
 
   describe('change parameter target', function() {
+
 
     describe('input', function() {
 
@@ -1234,7 +1224,6 @@ describe('customs - input output property tab', function() {
           expect(isInvalidInput(parameterTargetInput)).to.be.true;
         });
 
-
       });
 
 
@@ -1267,7 +1256,6 @@ describe('customs - input output property tab', function() {
           expect(parameter.target).to.equal('foo');
         }));
 
-
       });
 
     });
@@ -1297,7 +1285,9 @@ describe('customs - input output property tab', function() {
         triggerValue(parameterTargetOutput, 'foo', 'change');
       }));
 
+
       describe('in the DOM', function() {
+
 
         it('should execute', function() {
 
@@ -1345,7 +1335,6 @@ describe('customs - input output property tab', function() {
           // then
           expect(isInvalidInput(parameterTargetOutput)).to.be.true;
         });
-
 
       });
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/OutputParameterToggleSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/OutputParameterToggleSpec.js
@@ -1,0 +1,530 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  bootstrapModeler,
+  inject
+} from 'bpmn-js/test/helper';
+
+import { triggerEvent } from './helper';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { getExtensionElements } from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+
+import TestContainer from 'mocha-test-container-support';
+
+/* global sinon */
+
+import { query as domQuery } from 'min-dom';
+
+import contextPadModule from 'bpmn-js/lib/features/context-pad';
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import paletteModule from 'bpmn-js/lib/features/palette';
+import propertiesPanelModule from 'bpmn-js-properties-panel';
+import propertiesProviderModule from '..';
+import selectionModule from 'diagram-js/lib/features/selection';
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import customModelingModule from '../../modeling';
+import customModules from '../..';
+
+const HIDE_CLASS = 'bpp-hidden';
+
+
+describe('customs - input output property tab - output parameter toggle propagateAllChildVariables', function() {
+
+  const diagramXML = require('./InputOutput.bpmn');
+
+  const testModules = [
+    contextPadModule,
+    coreModule,
+    modelingModule,
+    paletteModule,
+    propertiesPanelModule,
+    propertiesProviderModule,
+    selectionModule,
+    customModelingModule,
+    customModules
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+  beforeEach(inject(function(propertiesPanel) {
+    propertiesPanel.attachTo(container);
+  }));
+
+
+  describe('availability', function() {
+
+    it('should display for CallActivity', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_1');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const propagateAllChildVariablesToggle = getPropagateAllChildVariablesToggle(container);
+
+        expect(propagateAllChildVariablesToggle).to.exist;
+        expect(propagateAllChildVariablesToggle.className).not.to.contain(HIDE_CLASS);
+      }));
+
+
+    it('should not display for ServiceTask', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_1');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const propagateAllChildVariablesToggle = getPropagateAllChildVariablesToggle(container);
+
+        expect(propagateAllChildVariablesToggle).to.not.exist;
+      }));
+
+  });
+
+  describe('show state', function() {
+
+    it('should display true when set to true', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_2');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const propagateAllChildVariablesToggleOn = getPropagateAllChildVariablesToggleLabelOn(container);
+        const propagateAllChildVariablesToggleOff = getPropagateAllChildVariablesToggleLabelOff(container);
+
+        expect(propagateAllChildVariablesToggleOn).to.exist;
+        expect(propagateAllChildVariablesToggleOn.classList.contains(HIDE_CLASS)).to.be.false;
+
+        expect(propagateAllChildVariablesToggleOff).to.exist;
+        expect(propagateAllChildVariablesToggleOff.classList.contains(HIDE_CLASS)).to.be.true;
+      }));
+
+
+    it('should display false when set to false', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_3');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const propagateAllChildVariablesToggleOn = getPropagateAllChildVariablesToggleLabelOn(container);
+        const propagateAllChildVariablesToggleOff = getPropagateAllChildVariablesToggleLabelOff(container);
+
+        expect(propagateAllChildVariablesToggleOn).to.exist;
+        expect(propagateAllChildVariablesToggleOn.classList.contains(HIDE_CLASS)).to.be.true;
+
+        expect(propagateAllChildVariablesToggleOff).to.exist;
+        expect(propagateAllChildVariablesToggleOff.classList.contains(HIDE_CLASS)).to.be.false;
+      }));
+
+
+    it('should display true when not set', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_4');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const propagateAllChildVariablesToggleOn = getPropagateAllChildVariablesToggleLabelOn(container);
+        const propagateAllChildVariablesToggleOff = getPropagateAllChildVariablesToggleLabelOff(container);
+
+        expect(propagateAllChildVariablesToggleOn).to.exist;
+        expect(propagateAllChildVariablesToggleOn.classList.contains(HIDE_CLASS)).to.be.false;
+
+        expect(propagateAllChildVariablesToggleOff).to.exist;
+        expect(propagateAllChildVariablesToggleOff.classList.contains(HIDE_CLASS)).to.be.true;
+      }));
+
+
+    it('should display false when not set but output mappings exist', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_5');
+
+        // when
+        selection.select(shape);
+
+        // then
+        const propagateAllChildVariablesToggleOn = getPropagateAllChildVariablesToggleLabelOn(container);
+        const propagateAllChildVariablesToggleOff = getPropagateAllChildVariablesToggleLabelOff(container);
+
+        expect(propagateAllChildVariablesToggleOn).to.exist;
+        expect(propagateAllChildVariablesToggleOn.classList.contains(HIDE_CLASS)).to.be.true;
+
+        expect(propagateAllChildVariablesToggleOff).to.exist;
+        expect(propagateAllChildVariablesToggleOff.classList.contains(HIDE_CLASS)).to.be.false;
+      }));
+
+  });
+
+  describe('update state', function() {
+
+    describe('toggle on', function() {
+
+      let calledElement;
+
+      beforeEach(inject(function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_3');
+        calledElement = getCalledElement(shape);
+
+        // when
+        selection.select(shape);
+        clickPropagateAllChildVariablesToggle(container);
+      }));
+
+
+      describe('in the DOM', function() {
+
+        it('should execute', function() {
+
+          // then
+          const propagateAllChildVariablesToggleOn = getPropagateAllChildVariablesToggleLabelOn(container);
+          const propagateAllChildVariablesToggleOff = getPropagateAllChildVariablesToggleLabelOff(container);
+
+          expect(propagateAllChildVariablesToggleOn).to.exist;
+          expect(propagateAllChildVariablesToggleOn.classList.contains(HIDE_CLASS)).to.be.false;
+
+          expect(propagateAllChildVariablesToggleOff).to.exist;
+          expect(propagateAllChildVariablesToggleOff.classList.contains(HIDE_CLASS)).to.be.true;
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          const propagateAllChildVariablesToggleOn = getPropagateAllChildVariablesToggleLabelOn(container);
+          const propagateAllChildVariablesToggleOff = getPropagateAllChildVariablesToggleLabelOff(container);
+
+          expect(propagateAllChildVariablesToggleOn).to.exist;
+          expect(propagateAllChildVariablesToggleOn.classList.contains(HIDE_CLASS)).to.be.true;
+
+          expect(propagateAllChildVariablesToggleOff).to.exist;
+          expect(propagateAllChildVariablesToggleOff.classList.contains(HIDE_CLASS)).to.be.false;
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          const propagateAllChildVariablesToggleOn = getPropagateAllChildVariablesToggleLabelOn(container);
+          const propagateAllChildVariablesToggleOff = getPropagateAllChildVariablesToggleLabelOff(container);
+
+          expect(propagateAllChildVariablesToggleOn).to.exist;
+          expect(propagateAllChildVariablesToggleOn.classList.contains(HIDE_CLASS)).to.be.false;
+
+          expect(propagateAllChildVariablesToggleOff).to.exist;
+          expect(propagateAllChildVariablesToggleOff.classList.contains(HIDE_CLASS)).to.be.true;
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should execute', function() {
+
+          // then
+          expect(calledElement.propagateAllChildVariables).to.equal(true);
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(calledElement.propagateAllChildVariables).to.equal(false);
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(calledElement.propagateAllChildVariables).to.equal(true);
+        }));
+
+      });
+
+    });
+
+
+    describe('toggle off', function() {
+
+      let calledElement;
+
+      beforeEach(inject(function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_2');
+        calledElement = getCalledElement(shape);
+
+        // when
+        selection.select(shape);
+        clickPropagateAllChildVariablesToggle(container);
+      }));
+
+
+      describe('in the DOM', function() {
+
+
+        it('should execute', function() {
+
+          // then
+          const propagateAllChildVariablesToggleOn = getPropagateAllChildVariablesToggleLabelOn(container);
+          const propagateAllChildVariablesToggleOff = getPropagateAllChildVariablesToggleLabelOff(container);
+
+          expect(propagateAllChildVariablesToggleOn).to.exist;
+          expect(propagateAllChildVariablesToggleOn.classList.contains(HIDE_CLASS)).to.be.true;
+
+          expect(propagateAllChildVariablesToggleOff).to.exist;
+          expect(propagateAllChildVariablesToggleOff.classList.contains(HIDE_CLASS)).to.be.false;
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          const propagateAllChildVariablesToggleOn = getPropagateAllChildVariablesToggleLabelOn(container);
+          const propagateAllChildVariablesToggleOff = getPropagateAllChildVariablesToggleLabelOff(container);
+
+          expect(propagateAllChildVariablesToggleOn).to.exist;
+          expect(propagateAllChildVariablesToggleOn.classList.contains(HIDE_CLASS)).to.be.false;
+
+          expect(propagateAllChildVariablesToggleOff).to.exist;
+          expect(propagateAllChildVariablesToggleOff.classList.contains(HIDE_CLASS)).to.be.true;
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          const propagateAllChildVariablesToggleOn = getPropagateAllChildVariablesToggleLabelOn(container);
+          const propagateAllChildVariablesToggleOff = getPropagateAllChildVariablesToggleLabelOff(container);
+
+          expect(propagateAllChildVariablesToggleOn).to.exist;
+          expect(propagateAllChildVariablesToggleOn.classList.contains(HIDE_CLASS)).to.be.true;
+
+          expect(propagateAllChildVariablesToggleOff).to.exist;
+          expect(propagateAllChildVariablesToggleOff.classList.contains(HIDE_CLASS)).to.be.false;
+        }));
+
+      });
+
+
+      describe('on the business object', function() {
+
+        it('should execute', function() {
+
+          // then
+          expect(calledElement.propagateAllChildVariables).to.equal(false);
+        });
+
+
+        it('should undo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(calledElement.propagateAllChildVariables).to.equal(true);
+        }));
+
+
+        it('should redo', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(calledElement.propagateAllChildVariables).to.equal(false);
+        }));
+
+      });
+
+    });
+
+  });
+
+
+  describe('execute <properties-panel.update-businessobject> command', function() {
+
+    describe('emitting the command', function() {
+
+      let executedListener;
+
+      beforeEach(inject(function(eventBus) {
+
+        // given
+        executedListener = sinon.spy(function() {});
+
+        eventBus.on('commandStack.properties-panel.update-businessobject.executed', executedListener);
+      }));
+
+
+      it('should execute when toggling on', inject(function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_3');
+
+        // when
+        selection.select(shape);
+        clickPropagateAllChildVariablesToggle(container);
+
+        // then
+        expect(executedListener).to.have.been.calledOnce;
+      }));
+
+
+      it('should execute when toggling off', inject(function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_2');
+
+        // when
+        selection.select(shape);
+        clickPropagateAllChildVariablesToggle(container);
+
+        // then
+        expect(executedListener).to.have.been.calledOnce;
+      }));
+
+    });
+
+
+    describe('emitting the propagateAllChildVariables payload', function() {
+
+      let payloadValue;
+
+      beforeEach(inject(function(eventBus) {
+
+        // given
+        const executedListener = sinon.spy(function(_, { context }) {
+          payloadValue = getBusinessObject(context).propagateAllChildVariables;
+        });
+
+        eventBus.on('commandStack.properties-panel.update-businessobject.executed', executedListener);
+      }));
+
+
+      it('should execute when toggling on', inject(function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_3');
+
+        // when
+        selection.select(shape);
+        clickPropagateAllChildVariablesToggle(container);
+
+        // then
+        expect(payloadValue).to.be.true;
+      }));
+
+
+      it('should execute when toggling off', inject(function(selection, elementRegistry) {
+
+        // given
+        const shape = elementRegistry.get('CallActivity_2');
+
+        // when
+        selection.select(shape);
+        clickPropagateAllChildVariablesToggle(container);
+
+        // then
+        expect(payloadValue).to.be.false;
+      }));
+
+    });
+
+  });
+
+});
+
+
+// helper /////////
+
+const getPropagateAllChildVariablesToggle = (container) => {
+  return domQuery('#output-propagate-all-toggle', container);
+};
+
+const getPropagateAllChildVariablesToggleLabelOn = (container) => {
+  return domQuery('p[data-show="isOn"]', container);
+};
+
+const getPropagateAllChildVariablesToggleLabelOff = (container) => {
+  return domQuery('p[data-show="isOff"]', container);
+};
+
+const clickPropagateAllChildVariablesToggle = (container) => {
+  const toggle = getPropagateAllChildVariablesToggle(container);
+  triggerEvent(toggle, 'click');
+};
+
+const getCalledElement = (element) => {
+  const bo = getBusinessObject(element);
+  const elements = getExtensionElements(bo, 'zeebe:CalledElement') || [];
+  return elements[0];
+};

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/CallActivityProps.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/CallActivityProps.js
@@ -14,7 +14,7 @@ import cmdHelper from 'bpmn-js-properties-panel/lib/helper/CmdHelper';
 
 import { isIdValid } from 'bpmn-js-properties-panel/lib/Utils';
 
-import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+import { getCalledElement } from '../../modeling/helper/CalledElementHelper';
 
 import {
   is,
@@ -92,15 +92,4 @@ export default function(group, element, bpmnFactory, translate) {
       return idError ? { processId: idError } : {};
     }
   }));
-}
-
-// helper //////////
-
-function getCalledElement(bo) {
-  const elements = getExtensionElements(bo, 'zeebe:CalledElement') || [];
-  return elements[0];
-}
-
-function getExtensionElements(bo, type) {
-  return extensionElementsHelper.getExtensionElements(bo, type);
 }

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/InputOutput.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/InputOutput.js
@@ -34,6 +34,8 @@ import {
 
 import InputOutputParameter from './InputOutputParameter';
 
+import OutputParameterToggle from './OutputParameterToggle';
+
 
 /**
  * Create an input or output mapping entry (containing multiple sub-entries).
@@ -50,8 +52,9 @@ import InputOutputParameter from './InputOutputParameter';
  * by n input / output parameter entries.
  */
 export default function(element, bpmnFactory, translate, options = {}) {
-  const result = {},
-        entries = result.entries = [];
+  const result = {
+    entries: []
+  };
 
   // Return if given moddle property is not supported for given element
   if (!options.prop ||
@@ -62,12 +65,19 @@ export default function(element, bpmnFactory, translate, options = {}) {
   }
 
   // Heading ///////////////////////////////////////////////////////////////
-  const entry = getParametersHeading(element, bpmnFactory, {
+  const heading = getParametersHeadingEntry(element, bpmnFactory, {
     type: options.type,
     prop: options.prop,
     prefix: options.prefix
   });
-  entries.push(entry);
+  result.entries = result.entries.concat(heading);
+
+  // Toggle ///////////////////////////////////////////////////////////////////
+  const toggle = OutputParameterToggle(element, bpmnFactory, translate, {
+    prefix: options.prefix,
+    prop: options.prop
+  });
+  result.entries = result.entries.concat(toggle);
 
   // Parameters ///////////////////////////////////////////////////////////////
   result.entries = result.entries.concat(getIOMappingEntries(element, bpmnFactory, translate, {
@@ -89,7 +99,7 @@ export default function(element, bpmnFactory, translate, options = {}) {
  *
  * @returns {Object} An Object representing a properties-panel heading entry.
  */
-function getParametersHeading(element, bpmnFactory, options) {
+function getParametersHeadingEntry(element, bpmnFactory, options) {
   const entry = {
     id: `${options.prefix}-heading`,
     cssClasses: [ 'bpp-input-output' ],
@@ -173,6 +183,7 @@ function getParametersHeading(element, bpmnFactory, options) {
     const input = domQuery('input[type="hidden"]', entryNode);
     input.value = 1;
   }
+
 }
 
 /**
@@ -204,7 +215,7 @@ function getIOMappingEntries(element, bpmnFactory, translate, options) {
 
   const parameters = params.map(function(param, index) {
 
-    return InputOutputParameter(param, bpmnFactory, translate,
+    return InputOutputParameter(param, translate,
       {
         idPrefix: `${options.prefix}-parameter-${index}`,
         onRemove: onRemove,

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/InputOutputParameter.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/InputOutputParameter.js
@@ -18,7 +18,6 @@ import { query as domQuery } from 'min-dom';
 /**
  * Create an input or output mapping entry for a single input or output entry
  * @param {Object} parameter - BusinessObject for the respective paramter (can be 'zeebe:Input' or 'zeebe:Output')
- * @param {Object} bpmnFactory - bpmn-js bpmn-factory.
  * @param {Function} translate - translate function.
  * @param {Object} options - Options.
  * @param {string} [options.idPrefix] - preFix used to construct the 'id' of the GUI entries
@@ -30,7 +29,7 @@ import { query as domQuery } from 'min-dom';
  * each representing a properties-panel entry. First entry will always be a collapsible followed
  * by two inputs (one for source and one for target).
  */
-export default function(parameter, bpmnFactory, translate, options = {}) {
+export default function(parameter, translate, options = {}) {
   const result = {},
         entries = result.entries = [];
 
@@ -66,15 +65,15 @@ export default function(parameter, bpmnFactory, translate, options = {}) {
     label: getTargetTextInputLabel(translate, options.prop),
     modelProperty: 'target',
 
-    getProperty: function(element, node) {
+    getProperty: function() {
       return parameter.target;
     },
 
-    setProperty: function(element, values, node) {
+    setProperty: function(element, values) {
       return cmdHelper.updateBusinessObject(element, parameter, values);
     },
 
-    validate: function(element, values, node) {
+    validate: function(element, values) {
       const validation = {},
             targetValue = values.target;
 
@@ -87,7 +86,7 @@ export default function(parameter, bpmnFactory, translate, options = {}) {
       return validation;
     },
 
-    hidden: function(element, node) {
+    hidden: function() {
       return !isOpen();
     }
   }));
@@ -98,15 +97,15 @@ export default function(parameter, bpmnFactory, translate, options = {}) {
     label: translate('Variable Assignment Value'),
     modelProperty: 'source',
 
-    getProperty: function(element, node) {
+    getProperty: function() {
       return parameter.source;
     },
 
-    setProperty: function(element, values, node) {
+    setProperty: function(element, values) {
       return cmdHelper.updateBusinessObject(element, parameter, values);
     },
 
-    validate: function(element, value, node) {
+    validate: function(element, value) {
       const validation = {},
             sourceValue = value.source;
 
@@ -119,7 +118,7 @@ export default function(parameter, bpmnFactory, translate, options = {}) {
       return validation;
     },
 
-    hidden: function(element, node) {
+    hidden: function() {
       return !isOpen();
     }
   }));

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/OutputParameterToggle.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/OutputParameterToggle.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import cmdHelper from 'bpmn-js-properties-panel/lib/helper/CmdHelper';
+
+import entryFactory from 'bpmn-js-properties-panel/lib/factory/EntryFactory';
+
+import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  getCalledElement,
+  isPropagateAllChildVariables
+} from '../../../modeling/helper/CalledElementHelper';
+
+
+/**
+ * Create an input or output mapping entry for a single input or output entry
+ * @param {Function} translate - translate function.
+ * @param {Object} options - Options.
+ * @param {string} [options.idPrefix] - preFix used to construct the 'id' of the GUI entries
+ * @param {string} [options.prop] - moddle (zeebe-bpmn-moddle) property name for the IOMapping.
+ *
+ * @returns {Object} An Object containing multiple Objects in its `entries` attribute,
+ * each representing a properties-panel entry. First entry will always be a collapsible followed
+ * by two inputs (one for source and one for target).
+ */
+export default function(element, bpmnFactory, translate, options = {}) {
+  if (!(is(element, 'bpmn:CallActivity') &&
+     options.prop === 'outputParameters')) {
+    return [];
+  }
+
+  const toggle = entryFactory.toggleSwitch(translate, {
+    id: `${options.prefix}-propagate-all-toggle`,
+    label: translate('Propagate all Child Process Variables'),
+    modelProperty: 'propagateAllChildVariables',
+    labelOn: translate('On'),
+    labelOff: translate('Off'),
+    descriptionOn: translate('All variables from the child process instance will be propagated to the parent process instance'),
+    descriptionOff: translate('Only variables defined via output mappings will be propagated from the child to the parent process instance'),
+    isOn: () => {
+      return isPropagateAllChildVariables(element);
+    },
+    get: () => {
+      return { propagateAllChildVariables: isPropagateAllChildVariables(element) };
+    },
+    set: function(element, values) {
+      let commands = [];
+
+      const propagateAllChildVariables = values.propagateAllChildVariables || false;
+
+      commands.push(setCalledElementProperties(element, bpmnFactory, { propagateAllChildVariables }));
+
+      return commands;
+    },
+    hidden: function() {
+      return false;
+    }
+  });
+
+  return toggle;
+
+}
+
+
+// helper //////////////////////////
+
+function setCalledElementProperties(element, bpmnFactory, values) {
+  const businessObject = getBusinessObject(element),
+        commands = [];
+
+  // ensure extensionElements
+  let extensionElements = businessObject.get('extensionElements');
+  if (!extensionElements) {
+    extensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, businessObject, bpmnFactory);
+    commands.push(cmdHelper.updateBusinessObject(element, businessObject, { extensionElements: extensionElements }));
+  }
+
+  // ensure zeebe:calledElement
+  let calledElement = getCalledElement(businessObject);
+  if (!calledElement) {
+    calledElement = elementHelper.createElement('zeebe:CalledElement', { }, extensionElements, bpmnFactory);
+    commands.push(cmdHelper.addAndRemoveElementsFromList(
+      element,
+      extensionElements,
+      'values',
+      'extensionElements',
+      [ calledElement ],
+      []
+    ));
+  }
+
+  // update properties
+  commands.push(cmdHelper.updateBusinessObject(element, calledElement, values));
+  return commands;
+}


### PR DESCRIPTION
__Which issue does this PR address?__

Closes #252
Closes #267

__Acceptance Criteria__

This includes three key changes to support the new
propagateAllChildVariables attribute on calledElement extensionElements:
(1): Behavior to initialize callActivities with
propagateAllChildVariables set to false per default (CreateZeebeCallActivityBehavior)
(2): toogle UI component to controll the attribute and to display it
accordingly to engine logic in case it is not set (legacy diagrams)
(OutputParameterToggle)
(3): behavior to keep the attribute in sync with outputParameters
(UpdatePropagateAllChildVariablesBehavior)


<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
