### PR TITLE
Fix condition expression input layout

### DIFF
--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/SequenceFlowProps.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/SequenceFlowProps.js
@@ -49,7 +49,7 @@ export default function(group, element, bpmnFactory, translate) {
               </label>
               <div class="bpp-field-wrapper">
                 <input id="zeebe-condition" type="text" name="condition" />
-                <button class="clear" data-action="clear" data-show="canClear">
+                <button class="action-button clear" data-action="clear" data-show="canClear">
                  <span>X</span>
                 </button>
               </div>


### PR DESCRIPTION
__Solution__

The <button> element was missing a class defining the layout of the `x` clear button

__Which issue does this PR address?__

Closes https://github.com/zeebe-io/zeebe-modeler/issues/268

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
