### PR TITLE
Integrate zeebe-bpmn-moddle extension

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12573,9 +12573,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.1.0.tgz",
-      "integrity": "sha512-gYjW2y71v4ioU/jWp83nFifIOz2HVWKak2LfT6CVRGoPTQfD1YeRBMP3ePpbCABJtYYbVU41KNmpGhSxMdqkCQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.4.0.tgz",
+      "integrity": "sha512-rsONgZ3i2GyGG48o/sG/xaneZmigp9kCdwR36vCUEXECpfwvttX3Ke2aeKjxv61/sPOXcO8LTLOaeZp0OZZmEA=="
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -34,7 +34,7 @@
     "saxen": "^8.1.2",
     "scroll-tabs": "^1.0.1",
     "sourcemapped-stacktrace": "^1.1.9",
-    "zeebe-bpmn-moddle": "^0.1.0"
+    "zeebe-bpmn-moddle": "^0.4.0"
   },
   "homepage": ".",
   "devDependencies": {

--- a/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
@@ -34,7 +34,9 @@ import propertiesProviderModule from '../custom/properties-provider';
 
 import zeebeModelingModule from '../custom/modeling';
 
-import zeebeModdleExtension from 'zeebe-bpmn-moddle/resources/zeebe';
+import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import zeebeModdleExtension from 'zeebe-bpmn-moddle/lib';
 
 import zeebeCustoms from '../custom';
 
@@ -61,7 +63,7 @@ export default class ZeebeBpmnModeler extends BpmnModeler {
     super({
       ...otherOptions,
       moddleExtensions: {
-        zeebe: zeebeModdleExtension,
+        zeebe: zeebeModdle,
         ...(moddleExtensions || {})
       }
     });


### PR DESCRIPTION
__Description__

Bumps zeebe-bpmn-moddle to v0.3.0 and integrates the new moddle extension.

The extension ensures that properties are allowed to be copied when replacing elements.
Eg. a `CallActivity` with a `calledElement` attribute changed to a simple `Task` won't have its `calledElement` copied because it's not allowed on `Task` elements, in accordance with the json schema.

The schema itself is incomplete in its current version and doesn't specify for instance that a `<zeebe:TaskDefinition>` isn't allowed on anything else than a `ServiceTask`, implicitely allowing the property to be copied regardless of the parent element's type.

See https://github.com/zeebe-io/zeebe-bpmn-moddle/issues/4 for context

__Which issue does this PR address?__

Closes #248 

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
