### PR TITLE
Add process id of participant to properties panel

### DIFF
--- a/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
@@ -14,6 +14,8 @@ import idProps from 'bpmn-js-properties-panel/lib/provider/bpmn/parts/IdProps';
 
 import nameProps from 'bpmn-js-properties-panel/lib/provider/bpmn/parts/NameProps';
 
+import processProps from 'bpmn-js-properties-panel/lib/provider/bpmn/parts/ProcessProps';
+
 import executableProps from 'bpmn-js-properties-panel/lib/provider/bpmn/parts/ExecutableProps';
 
 import inputOutput from './parts/InputOutputProps';
@@ -43,6 +45,7 @@ function createGeneralTabGroups(element, bpmnFactory, canvas, translate) {
   };
   idProps(generalGroup, element, translate);
   nameProps(generalGroup, element, bpmnFactory, canvas, translate);
+  processProps(generalGroup, element, translate);
   executableProps(generalGroup, element, translate);
 
   const detailsGroup = {

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/ParticipantProcess.bpmn
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/ParticipantProcess.bpmn
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1xwc1bf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.12.0-dev.20210107">
+  <bpmn:collaboration id="Collaboration_1b2a6d1">
+    <bpmn:participant id="Participant_1" name="Participant_1" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" name="Process_1" isExecutable="true" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1b2a6d1">
+      <bpmndi:BPMNShape id="Participant_0utji7m_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="160" y="85" width="600" height="250" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/ParticipantProcessSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/ParticipantProcessSpec.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  bootstrapModeler,
+  inject
+} from 'bpmn-js/test/helper';
+
+import TestContainer from 'mocha-test-container-support';
+
+import propertiesPanelModule from 'bpmn-js-properties-panel';
+
+import {
+  query as domQuery,
+  classes as domClasses
+} from 'min-dom';
+
+
+import coreModule from 'bpmn-js/lib/core';
+import selectionModule from 'diagram-js/lib/features/selection';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import propertiesProviderModule from '..';
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+describe('zeebe-properties-provider', function() {
+
+  const diagramXML = require('./ParticipantProcess.bpmn');
+
+  const modules = [
+    coreModule,
+    selectionModule,
+    modelingModule,
+    propertiesPanelModule,
+    propertiesProviderModule
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules,
+    moddleExtensions
+  }));
+
+  beforeEach(inject(function(propertiesPanel) {
+    propertiesPanel.attachTo(container);
+  }));
+
+  describe('general tab', function() {
+
+    it('should show general group', inject(function(selection, elementRegistry) {
+
+      // given
+      const pool = elementRegistry.get('Participant_1');
+
+      // when
+      selection.select(pool);
+
+      // then
+      shouldHaveGroup(container, 'general', 'general');
+    }));
+
+
+    it('should have pool id and name inputs', inject(function(selection, elementRegistry) {
+
+      // given
+      const pool = elementRegistry.get('Participant_1');
+
+      // when
+      selection.select(pool);
+
+      // then
+      shouldHaveInput(container, 'general', 'id');
+      shouldHaveInput(container, 'general', 'name');
+    }));
+
+
+    it('should have pool process id and process name inputs', inject(function(selection, elementRegistry) {
+
+      // given
+      const pool = elementRegistry.get('Participant_1');
+
+      // when
+      selection.select(pool);
+
+      // then
+      shouldHaveInput(container, 'general', 'process-id');
+      shouldHaveInput(container, 'general', 'process-name');
+    }));
+
+  });
+
+});
+
+
+// helper /////////
+
+function getTab(container, tabName) {
+  return domQuery(`div[data-tab="${tabName}"]`, container);
+}
+
+function getGroup(container, tabName, groupName) {
+  const tab = getTab(container, tabName);
+  return domQuery(`div[data-group="${groupName}"]`, tab);
+}
+
+function getInput(container, tabName, inputName) {
+  const tab = getTab(container, tabName);
+  return domQuery(`div[data-entry="${inputName}"]`, tab);
+}
+
+const shouldHaveGroup = (container, tabName, groupName) => {
+  const group = getGroup(container, tabName, groupName);
+  expect(group).to.exist;
+  expect(domClasses(group).has('bpp-hidden')).to.be.false;
+};
+
+const shouldHaveInput = (container, tabName, inputName) => {
+  const input = getInput(container, tabName, inputName);
+  expect(input).to.exist;
+};


### PR DESCRIPTION
Closes #278

Adds the inputs to edit a participant's process name and id to the properties panel.

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
