### PR TITLE
feat(deployment): use last endpoint deployed for all files

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
@@ -185,8 +185,10 @@ export default class DeploymentPlugin extends PureComponent {
       return p.resolve(config);
     };
 
+    const defaultConfiguration = await this.getDefaultConfig(savedConfig, tab);
+
     const modalState = {
-      config: this.getDefaultConfig(savedConfig, tab),
+      config: defaultConfiguration,
       isStart: !!options.isStart,
       onClose
     };
@@ -234,24 +236,20 @@ export default class DeploymentPlugin extends PureComponent {
     }
 
     const {
-      deployment,
-      endpointId
+      deployment
     } = tabConfig;
-
-    const endpoints = await this.getEndpoints();
 
     return {
       deployment,
-      endpoint: endpoints.find(endpoint => endpoint.id === endpointId)
     };
   }
 
-  getDefaultConfig(savedConfig, tab) {
+  async getDefaultConfig(savedConfig, tab) {
     const deployment = {
       name: withoutExtension(tab.name)
     };
 
-    const endpoint = {
+    let endpoint = {
       id: generateId(),
       targetType: SELF_HOSTED,
       authType: AUTH_TYPES.NONE,
@@ -266,15 +264,17 @@ export default class DeploymentPlugin extends PureComponent {
       rememberCredentials: false
     };
 
+    const previousEndpoints = await this.getEndpoints();
+    if (previousEndpoints.length) {
+      endpoint = previousEndpoints[0];
+    }
+
     return {
       deployment: {
         ...deployment,
         ...savedConfig.deployment
       },
-      endpoint: {
-        ...endpoint,
-        ...savedConfig.endpoint
-      }
+      endpoint
     };
   }
 


### PR DESCRIPTION
In accordance with https://github.com/bpmn-io/internal-docs/issues/224, this PR aligns the Zeebe Modeler deployment plugin with the Camunda Modeler one.

__Which issue does this PR address?__

Closes #227 

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
