### PR TITLE
 Add 'participant-' prefix to name and id inputs for clarity

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2052,9 +2052,9 @@
       "integrity": "sha512-AHeZUM/mF/FY5goZY0ooxcHS6KxJJD//tQ+6Mn14GLn1ECJGUyFwDvCWEJyc4VYYHgOBosR6zhbpB6XFik1z/A=="
     },
     "bpmn-js-properties-panel": {
-      "version": "0.37.6",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-0.37.6.tgz",
-      "integrity": "sha512-1rP9r6ItL1gKqXezXnpr9eVsQtdufH6TNqxUs11Q68CtxeBAs0l1wEHw2f01i9ceHHxItmrZUTndqnASi89EYA==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-0.39.0.tgz",
+      "integrity": "sha512-L9Jd2pKUl2nPVp8F7THxOyyseEZLfNj+CFFtELMeYM7DAdCSWL/CcviHwl2xIqYbY8SDkrM7fmKEaT35fvUL7Q==",
       "requires": {
         "@bpmn-io/extract-process-variables": "^0.3.0",
         "ids": "^1.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     "bpmn-js": "^7.5.0",
     "bpmn-js-disable-collapsed-subprocess": "^0.1.2",
     "bpmn-js-executable-fix": "^0.1.2",
-    "bpmn-js-properties-panel": "^0.37.6",
+    "bpmn-js-properties-panel": "0.39.0",
     "bpmn-js-signavio-compat": "^1.2.2",
     "canvg-browser": "^1.0.0",
     "classnames": "^2.2.6",

--- a/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/ZeebePropertiesProvider.js
@@ -36,6 +36,19 @@ import errorProps from './parts/ErrorProps';
 
 import callActivityProps from './parts/CallActivityProps';
 
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+function getIdOptions(element) {
+  if (is(element, 'bpmn:Participant')) {
+    return { id: 'participant-id', label: 'Participant Id' };
+  }
+}
+
+function getNameOptions(element) {
+  if (is(element, 'bpmn:Participant')) {
+    return { id: 'participant-name', label: 'Participant Name' };
+  }
+}
 
 function createGeneralTabGroups(element, bpmnFactory, canvas, translate) {
   const generalGroup = {
@@ -43,8 +56,9 @@ function createGeneralTabGroups(element, bpmnFactory, canvas, translate) {
     label: translate('General'),
     entries: []
   };
-  idProps(generalGroup, element, translate);
-  nameProps(generalGroup, element, bpmnFactory, canvas, translate);
+
+  idProps(generalGroup, element, translate, getIdOptions(element));
+  nameProps(generalGroup, element, bpmnFactory, canvas, translate, getNameOptions(element));
   processProps(generalGroup, element, translate);
   executableProps(generalGroup, element, translate);
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/ParticipantProcessSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/ParticipantProcessSpec.js
@@ -84,8 +84,8 @@ describe('zeebe-properties-provider', function() {
       selection.select(pool);
 
       // then
-      shouldHaveInput(container, 'general', 'id');
-      shouldHaveInput(container, 'general', 'name');
+      shouldHaveInput(container, 'general', 'participant-id');
+      shouldHaveInput(container, 'general', 'participant-name');
     }));
 
 


### PR DESCRIPTION
This PR adds a "participant-" prefix to the input labels defining the name and id of a participant in the properties panel.

Waiting for https://github.com/bpmn-io/bpmn-js-properties-panel/pull/413 to be merged
and for the next version of https://github.com/bpmn-io/bpmn-js-properties-panel/ to be released
so this PR can add the version bump and have everything working properly.

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
