### PR TITLE
Update usages of extension elements helper to align with new return value

### DIFF
--- a/client/src/app/tabs/bpmn/custom/modeling/helper/CalledElementHelper.js
+++ b/client/src/app/tabs/bpmn/custom/modeling/helper/CalledElementHelper.js
@@ -45,8 +45,8 @@ export function getCalledElement(element) {
 
 export function getCalledElements(element) {
   const bo = getBusinessObject(element);
-  const extElement = getExtensionElements(bo, 'zeebe:CalledElement');
-  return extElement;
+  const extElements = getExtensionElements(bo, 'zeebe:CalledElement');
+  return extElements;
 }
 
 /**

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/CallActivitySpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/CallActivitySpec.js
@@ -103,7 +103,7 @@ describe('customs - call activity', function() {
         bo = getBusinessObject(shape);
 
         // assume
-        expect(getCalledElement(bo)).to.be.undefined;
+        expect(getCalledElement(bo)).to.be.empty;
       }));
 
       it('should fail', function() {
@@ -274,7 +274,7 @@ const getCalledElement = (bo) => {
     bo,
     'zeebe:CalledElement'
   );
-  return (extensions || [])[0];
+  return extensions[0];
 };
 
 const getGeneralTab = (container) => {

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/HeadersSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/HeadersSpec.js
@@ -90,7 +90,7 @@ describe('customs - headers property tab', function() {
       bo = getBusinessObject(shape);
 
       // assume
-      expect(getTaskHeaders(bo)).to.be.undefined;
+      expect(getTaskHeaders(bo)).to.be.empty;
 
       // when
       clickAddHeaderButton(container);
@@ -111,7 +111,7 @@ describe('customs - headers property tab', function() {
       commandStack.undo();
 
       // then
-      expect(getTaskHeaders(bo)).to.be.undefined;
+      expect(getTaskHeaders(bo)).to.be.empty;
 
     }));
 
@@ -246,7 +246,7 @@ describe('customs - headers property tab', function() {
     it('should execute', function() {
 
       // then
-      expect(getTaskHeaders(bo)).to.be.undefined;
+      expect(getTaskHeaders(bo)).to.be.empty;
 
     });
 
@@ -270,7 +270,7 @@ describe('customs - headers property tab', function() {
       commandStack.redo();
 
       // then
-      expect(getTaskHeaders(bo)).to.be.undefined;
+      expect(getTaskHeaders(bo)).to.be.empty;
 
     }));
 
@@ -282,7 +282,7 @@ describe('customs - headers property tab', function() {
 // helper /////////
 
 const getTaskHeader = (headers) => {
-  if (headers.length <= 0) {
+  if (!headers.length) {
     return;
   }
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutputSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/InputOutputSpec.js
@@ -837,7 +837,7 @@ describe('customs - input output property tab', function() {
       bo = getBusinessObject(shape);
 
       // assume
-      expect(getIOMapping(bo)).to.exist;
+      expect(getIOMapping(bo)).not.to.be.empty;
 
       // when
       clickRemoveInputParameterButton(container, 0);
@@ -850,7 +850,7 @@ describe('customs - input output property tab', function() {
       it('should execute', function() {
 
         // then
-        expect(getIOMapping(bo)).not.to.exist;
+        expect(getIOMapping(bo)).to.be.empty;
       });
 
 
@@ -860,7 +860,7 @@ describe('customs - input output property tab', function() {
         commandStack.undo();
 
         // then
-        expect(getIOMapping(bo)).to.exist;
+        expect(getIOMapping(bo)).not.to.be.empty;
       }));
 
 
@@ -871,7 +871,7 @@ describe('customs - input output property tab', function() {
         commandStack.redo();
 
         // then
-        expect(getIOMapping(bo)).not.to.exist;
+        expect(getIOMapping(bo)).to.be.empty;
       }));
 
     });
@@ -1391,7 +1391,7 @@ const getOutputParameters = (bo) => {
 };
 
 const getElements = (bo, type, prop) => {
-  const elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  const elems = extensionElementsHelper.getExtensionElements(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
 };
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/MessageSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/MessageSpec.js
@@ -505,7 +505,7 @@ describe('customs - message properties', function() {
         it('subscription definitions should not exist', function() {
 
           // then
-          expect(subscriptionDefinitions).to.be.undefined;
+          expect(subscriptionDefinitions).to.be.empty;
         });
       });
     });

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/MultiInstanceLoopSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/MultiInstanceLoopSpec.js
@@ -767,7 +767,7 @@ const getZeebeLoopCharacteristics = (bo) => {
     bo.loopCharacteristics,
     'zeebe:LoopCharacteristics'
   );
-  return (extensions || [])[0];
+  return extensions[0];
 };
 
 const getGeneralTab = (container) => {

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/OutputParameterToggleSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/OutputParameterToggleSpec.js
@@ -525,6 +525,6 @@ const clickPropagateAllChildVariablesToggle = (container) => {
 
 const getCalledElement = (element) => {
   const bo = getBusinessObject(element);
-  const elements = getExtensionElements(bo, 'zeebe:CalledElement') || [];
+  const elements = getExtensionElements(bo, 'zeebe:CalledElement');
   return elements[0];
 };

--- a/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/TaskDefinitionSpec.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/__tests__/TaskDefinitionSpec.js
@@ -93,7 +93,7 @@ describe('customs - task definition properties', function() {
         bo = getBusinessObject(shape);
 
         // assume
-        expect(getTaskDefinitions(bo)).to.be.undefined;
+        expect(getTaskDefinitions(bo)).to.be.empty;
 
         const input = getInputField(container, 'camunda-taskDefinitionType', 'type');
 
@@ -115,7 +115,7 @@ describe('customs - task definition properties', function() {
         commandStack.undo();
 
         // then
-        expect(getTaskDefinitions(bo)).to.be.undefined;
+        expect(getTaskDefinitions(bo)).to.be.empty;
 
       }));
 
@@ -294,7 +294,7 @@ describe('customs - task definition properties', function() {
         bo = getBusinessObject(shape);
 
         // assume
-        expect(getTaskDefinitions(bo)).to.be.undefined;
+        expect(getTaskDefinitions(bo)).to.be.empty;
 
         const input = getInputField(container, 'camunda-taskDefinitionRetries', 'retries');
 
@@ -316,7 +316,7 @@ describe('customs - task definition properties', function() {
         commandStack.undo();
 
         // then
-        expect(getTaskDefinitions(bo)).to.be.undefined;
+        expect(getTaskDefinitions(bo)).to.be.empty;
 
       }));
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/helper/InputOutputHelper.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/helper/InputOutputHelper.js
@@ -22,7 +22,7 @@ import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
 
 
 function getElements(bo, type, prop) {
-  const elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  const elems = extensionElementsHelper.getExtensionElements(bo, type);
   return !prop ? elems : (elems[0] || {})[prop] || [];
 }
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/TaskDefinitionProps.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/TaskDefinitionProps.js
@@ -28,7 +28,7 @@ export default function(group, element, bpmnFactory, translate) {
   }
 
   function getElements(bo, type, prop) {
-    const elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+    const elems = extensionElementsHelper.getExtensionElements(bo, type);
     return !prop ? elems : (elems[0] || {})[prop] || [];
   }
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/ElementReferenceExtensionElementProperty.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/ElementReferenceExtensionElementProperty.js
@@ -49,7 +49,7 @@ export default function(element, definition, bpmnFactory, translate, options) {
 
 
   function getElements(bo, type, prop) {
-    const elems = extensionElementsHelper.getExtensionElements(bo, type) || [];
+    const elems = extensionElementsHelper.getExtensionElements(bo, type);
     return !prop ? elems : (elems[0] || {})[prop] || [];
   }
 

--- a/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/MultiInstanceLoopCharacteristics.js
+++ b/client/src/app/tabs/bpmn/custom/properties-provider/parts/implementation/MultiInstanceLoopCharacteristics.js
@@ -170,7 +170,7 @@ export default function(element, bpmnFactory, translate) {
 // helper /////////
 
 function getExtensionElements(bo, type, prop) {
-  const elements = extensionElementsHelper.getExtensionElements(bo, type) || [];
+  const elements = extensionElementsHelper.getExtensionElements(bo, type);
   return !prop ? elements : (elements[0] || {})[prop] || [];
 }
 


### PR DESCRIPTION
This PR prepares the zeebe-modeler's properties panel to the change made to the bpmn-js-properties-panel's extension elements helper, returning an empty array instead of undefined.
Tests are currently failing because they are waiting for bpmn-io/bpmn-js-properties-panel#447 to be merged.

Related to bpmn-io/bpmn-js-properties-panel#447

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
