### PR TITLE
update brew cask install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The visual workflow editor for [Zeebe](https://zeebe.io/) based on [bpmn.io](htt
 Requires [homebrew](https://brew.sh/index_de.html) and [cask](https://caskroom.github.io):
 
 ```sh
-brew cask install zeebe-modeler
+brew install --cask zeebe-modeler
 ```
 
 #### Windows (using Scoop)


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524